### PR TITLE
fix runtime error when vault path not found

### DIFF
--- a/pkg/providers/hashicorp_vault.go
+++ b/pkg/providers/hashicorp_vault.go
@@ -129,7 +129,7 @@ func (h *HashicorpVault) getSecret(kp core.KeyPath) (*api.Secret, error) {
 	}
 
 	if secret == nil || len(secret.Data) == 0 {
-		return nil, nil
+		return nil, fmt.Errorf("secret not found in path: %s", kp.Path)
 	}
 
 	if len(secret.Warnings) > 0 {


### PR DESCRIPTION
## Related Issues
#115

## Description
Fix run time error when secret not found


## How This Been Tested?
Created a yaml file with incorrect file path:
```sh
panic: runtime error: invalid memory address or nil pointer dereference
...
```

