### PR TITLE
support fetch AWS secret by specific version

### DIFF
--- a/pkg/wizard_template.go
+++ b/pkg/wizard_template.go
@@ -67,6 +67,7 @@ providers:
 
 {{- if index .ProviderKeys "aws_secretsmanager" }}
   # configure only from environment
+  # filter secret versioning by adding comma separating in path value (path: prod/foo/bar,<VERSION>).
   aws_secretsmanager:
     env_sync:
       path: prod/foo/bar


### PR DESCRIPTION
## Related Issues
#117 

## Description
Support fetch AWS secret by specific version



## How Has This Been Tested?
Teller yaml config
```yaml
providers:
  aws_secretsmanager:
    # env_sync:
    #   path: <KEY>,<VERSION>
   
```

# Checklist
- [ ] Tests
- [x] Documentation
- [x] Linting