### PR TITLE
Add process_env provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1129,6 +1129,31 @@ providers:
         path: /folder/bar
 ```
 
+
+## ProcessEnv
+
+Load the environment variables from the parent process as needed.
+
+### Authentication
+No need.
+
+### Features
+
+* Sync - `yes`
+* Mapping - `yes`
+* Modes - `read`
+
+### Example Config
+
+```yaml
+providers:
+  process_env:
+    env_sync:
+
+    env:
+      ETC_DSN:
+```
+
 ## Azure
 
 ### Authentication

--- a/README.md
+++ b/README.md
@@ -1142,16 +1142,21 @@ No need.
 * Sync - `yes`
 * Mapping - `yes`
 * Modes - `read`
+* Key format
+  * `env_sync` - Will return all the environment variables in the parent process
+    * `path` - Value isn't required or used
+  * `env`
+    * `field` - Optional field: specific environment variable in the parent process
 
 ### Example Config
 
 ```yaml
 providers:
   process_env:
-    env_sync:
-
     env:
       ETC_DSN:
+        # Optional: accesses the environment variable `SOME_KEY` and maps it to ETC_DSN
+        field: SOME_KEY
 ```
 
 ## Azure

--- a/pkg/providers.go
+++ b/pkg/providers.go
@@ -38,6 +38,7 @@ func (p *BuiltinProviders) ProviderHumanToMachine() map[string]string {
 		"GitHub":                      "github",
 		"KeyPass":                     "keypass",
 		"FileSystem":                  "filesystem",
+		"ProcessEnv":                  "process_env",
 	}
 }
 
@@ -84,6 +85,8 @@ func (p *BuiltinProviders) GetProvider(name string) (core.Provider, error) { //n
 		return providers.NewKeyPass(logger)
 	case "filesystem":
 		return providers.NewFileSystem(logger)
+	case "process_env":
+		return providers.NewProcessEnv(logger)
 	default:
 		return nil, fmt.Errorf("provider '%s' does not exist", name)
 	}

--- a/pkg/providers/process_env.go
+++ b/pkg/providers/process_env.go
@@ -32,7 +32,7 @@ func (a *ProcessEnv) GetMapping(p core.KeyPath) ([]core.EnvEntry, error) {
 
 	kvs := make(map[string]string)
 	for _, envs := range os.Environ() {
-		pair := strings.SplitN(envs, "=", 2)
+		pair := strings.SplitN(envs, "=", 2) // nolint: gomnd
 		kvs[pair[0]] = pair[1]
 	}
 	var entries []core.EnvEntry

--- a/pkg/providers/process_env.go
+++ b/pkg/providers/process_env.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"fmt"
 	"os"
 	"sort"
 	"strings"
@@ -61,20 +62,20 @@ func (a *ProcessEnv) Get(p core.KeyPath) (*core.EnvEntry, error) {
 
 // Delete will delete entry
 func (a *ProcessEnv) Delete(kp core.KeyPath) error {
-	return fmt.Errorf("%s does not implement delete yet", a.Name())
+	return fmt.Errorf("provider %s does not implement delete yet", a.Name())
 }
 
 // DeleteMapping will delete the given path recessively
 func (a *ProcessEnv) DeleteMapping(kp core.KeyPath) error {
-	return fmt.Errorf("%s does not implement delete yet", a.Name())
+	return fmt.Errorf("provider %s does not implement delete yet", a.Name())
 }
 
 // Put will create a new single entry
 func (a *ProcessEnv) Put(p core.KeyPath, val string) error {
-	return fmt.Errorf("%s does not implement delete yet", a.Name())
+	return fmt.Errorf("provider %s does not implement write yet", a.Name())
 }
 
 // PutMapping will create a multiple entries
 func (a *ProcessEnv) PutMapping(p core.KeyPath, m map[string]string) error {
-	return fmt.Errorf("%s does not implement delete yet", a.Name())
+	return fmt.Errorf("provider %s does not implement write yet", a.Name())
 }

--- a/pkg/providers/process_env.go
+++ b/pkg/providers/process_env.go
@@ -76,5 +76,5 @@ func (a *ProcessEnv) Put(p core.KeyPath, val string) error {
 
 // PutMapping will create a multiple entries
 func (a *ProcessEnv) PutMapping(p core.KeyPath, m map[string]string) error {
-	return nil
+	return fmt.Errorf("%s does not implement delete yet", a.Name())
 }

--- a/pkg/providers/process_env.go
+++ b/pkg/providers/process_env.go
@@ -61,7 +61,7 @@ func (a *ProcessEnv) Get(p core.KeyPath) (*core.EnvEntry, error) {
 
 // Delete will delete entry
 func (a *ProcessEnv) Delete(kp core.KeyPath) error {
-	return nil
+	return fmt.Errorf("%s does not implement delete yet", a.Name())
 }
 
 // DeleteMapping will delete the given path recessively

--- a/pkg/providers/process_env.go
+++ b/pkg/providers/process_env.go
@@ -71,7 +71,7 @@ func (a *ProcessEnv) DeleteMapping(kp core.KeyPath) error {
 
 // Put will create a new single entry
 func (a *ProcessEnv) Put(p core.KeyPath, val string) error {
-	return nil
+	return fmt.Errorf("%s does not implement delete yet", a.Name())
 }
 
 // PutMapping will create a multiple entries

--- a/pkg/providers/process_env.go
+++ b/pkg/providers/process_env.go
@@ -66,7 +66,7 @@ func (a *ProcessEnv) Delete(kp core.KeyPath) error {
 
 // DeleteMapping will delete the given path recessively
 func (a *ProcessEnv) DeleteMapping(kp core.KeyPath) error {
-	return nil
+	return fmt.Errorf("%s does not implement delete yet", a.Name())
 }
 
 // Put will create a new single entry

--- a/pkg/providers/process_env.go
+++ b/pkg/providers/process_env.go
@@ -1,0 +1,80 @@
+package providers
+
+import (
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spectralops/teller/pkg/core"
+
+	"github.com/spectralops/teller/pkg/logging"
+)
+
+type ProcessEnv struct {
+	logger logging.Logger
+}
+
+// NewProcessEnv creates new provider instance
+func NewProcessEnv(logger logging.Logger) (core.Provider, error) {
+	return &ProcessEnv{
+		logger: logger,
+	}, nil
+}
+
+// Name return the provider name
+func (a *ProcessEnv) Name() string {
+	return "process_env"
+}
+
+// GetMapping returns a multiple entries
+func (a *ProcessEnv) GetMapping(p core.KeyPath) ([]core.EnvEntry, error) {
+	a.logger.Debug("read secret")
+
+	kvs := make(map[string]string)
+	for _, envs := range os.Environ() {
+		pair := strings.SplitN(envs, "=", 2)
+		kvs[pair[0]] = pair[1]
+	}
+	var entries []core.EnvEntry
+	for k, v := range kvs {
+		entries = append(entries, p.FoundWithKey(k, v))
+	}
+	sort.Sort(core.EntriesByKey(entries))
+	return entries, nil
+}
+
+// Get returns a single entry
+func (a *ProcessEnv) Get(p core.KeyPath) (*core.EnvEntry, error) {
+	a.logger.Debug("read secret")
+
+	k := p.EffectiveKey()
+	val, ok := os.LookupEnv(k)
+	if !ok {
+		a.logger.WithFields(map[string]interface{}{"key": k}).Debug("key not found")
+		ent := p.Missing()
+		return &ent, nil
+	}
+
+	ent := p.Found(val)
+	return &ent, nil
+}
+
+// Delete will delete entry
+func (a *ProcessEnv) Delete(kp core.KeyPath) error {
+	return nil
+}
+
+// DeleteMapping will delete the given path recessively
+func (a *ProcessEnv) DeleteMapping(kp core.KeyPath) error {
+	return nil
+}
+
+// Put will create a new single entry
+func (a *ProcessEnv) Put(p core.KeyPath, val string) error {
+	return nil
+}
+
+// PutMapping will create a multiple entries
+func (a *ProcessEnv) PutMapping(p core.KeyPath, m map[string]string) error {
+	return nil
+}

--- a/pkg/providers/process_env.go
+++ b/pkg/providers/process_env.go
@@ -67,15 +67,15 @@ func (a *ProcessEnv) Delete(kp core.KeyPath) error {
 
 // DeleteMapping will delete the given path recessively
 func (a *ProcessEnv) DeleteMapping(kp core.KeyPath) error {
-	return fmt.Errorf("provider %s does not implement delete yet", a.Name())
+	return fmt.Errorf("provider %s does not implement deleteMapping yet", a.Name())
 }
 
 // Put will create a new single entry
 func (a *ProcessEnv) Put(p core.KeyPath, val string) error {
-	return fmt.Errorf("provider %s does not implement write yet", a.Name())
+	return fmt.Errorf("provider %s does not implement put yet", a.Name())
 }
 
 // PutMapping will create a multiple entries
 func (a *ProcessEnv) PutMapping(p core.KeyPath, m map[string]string) error {
-	return fmt.Errorf("provider %s does not implement write yet", a.Name())
+	return fmt.Errorf("provider %s does not implement putMapping yet", a.Name())
 }

--- a/pkg/providers/process_env_test.go
+++ b/pkg/providers/process_env_test.go
@@ -1,0 +1,1 @@
+package providers

--- a/pkg/wizard_template.go
+++ b/pkg/wizard_template.go
@@ -262,9 +262,9 @@ providers:
 {{- if index .ProviderKeys "process_env" }}
 
   process_env:
-    env_sync:
     env:
       ETC_DSN:
+        field: # Optional, specific environment variable in the parent process
 
 {{end}}
 `

--- a/pkg/wizard_template.go
+++ b/pkg/wizard_template.go
@@ -264,7 +264,7 @@ providers:
   process_env:
     env:
       ETC_DSN:
-        field: # Optional, specific environment variable in the parent process
+        field: SOME_KEY # Optional, accesses the environment variable SOME_KEY and maps it to ETC_DSN
 
 {{end}}
 `

--- a/pkg/wizard_template.go
+++ b/pkg/wizard_template.go
@@ -258,4 +258,13 @@ providers:
         path: redis/config/foobar
 
 {{end}}
+
+{{- if index .ProviderKeys "process_env" }}
+
+  process_env:
+    env_sync:
+    env:
+      ETC_DSN:
+
+{{end}}
 `


### PR DESCRIPTION
## Related Issues
https://github.com/tellerops/teller/issues/116

## Description
Add `process_env` provider.  Load the environment variables from the parent process as needed.

### Example Config

```yaml
providers:
  process_env:
    env_sync:

    env:
      ETC_DSN:
```

# Checklist
- [ ] Tests
- [x] Documentation
- [x] Linting