### PR TITLE
Support special characters in teller sh

### DIFF
--- a/e2e/tests/sh.yml
+++ b/e2e/tests/sh.yml
@@ -1,0 +1,46 @@
+---
+name: Sh print
+command: <binary-path> sh
+config_file_name: .teller.yml
+config_content: >
+  project: test
+
+  providers:
+    filesystem:
+      env_sync:
+        path: {{.Folder}}/settings/test/all
+      env:
+        FOO:
+          path: {{.Folder}}/settings/test/foo
+        BAR:
+          path: {{.Folder}}/settings/test/bar
+init_snapshot:
+  - path: settings/test
+    file_name: foo
+    content: shazam
+  - path: settings/test
+    file_name: bar
+    content: shazam
+  - path: settings/test/all
+    file_name: secret-a
+    content: mailman
+  - path: settings/test/all
+    file_name: secret-b
+    content: shazam
+  - path: settings/test/all
+    file_name: secret-c
+    content: shazam-1
+  - path: settings/test/all
+    file_name: secret-d
+    content: ()"';@ \(\)\"\'\;\@
+
+expected_snapshot:
+expected_stderr:
+expected_stdout: |
+  #!/bin/sh
+  export secret-d='()"'"'"';@ \(\)\"\'"'"'\;\@'
+  export secret-c='shazam-1'
+  export secret-b='shazam'
+  export secret-a='mailman'
+  export FOO='shazam'
+  export BAR='shazam'

--- a/pkg/teller.go
+++ b/pkg/teller.go
@@ -99,7 +99,8 @@ func (tl *Teller) ExportEnv() string {
 	fmt.Fprintf(&b, "#!/bin/sh\n")
 	for i := range tl.Entries {
 		v := tl.Entries[i]
-		fmt.Fprintf(&b, "export %s=%s\n", v.Key, v.Value)
+		value := strings.ReplaceAll(v.Value, "'", "'\"'\"'")
+		fmt.Fprintf(&b, "export %s='%s'\n", v.Key, value)
 	}
 	return b.String()
 }

--- a/pkg/teller_test.go
+++ b/pkg/teller_test.go
@@ -134,7 +134,7 @@ func TestTellerExports(t *testing.T) {
 	}
 
 	b = tl.ExportEnv()
-	assert.Equal(t, b, "#!/bin/sh\nexport k=v\n")
+	assert.Equal(t, b, "#!/bin/sh\nexport k='v'\n")
 
 	b, err := tl.ExportYAML()
 	assert.NoError(t, err)
@@ -142,6 +142,27 @@ func TestTellerExports(t *testing.T) {
 	b, err = tl.ExportJSON()
 	assert.NoError(t, err)
 	assert.Equal(t, b, "{\n  \"k\": \"v\"\n}")
+}
+
+func TestTellerShExportEscaped(t *testing.T) {
+	tl := Teller{
+		Logger:    getLogger(),
+		Entries:   []core.EnvEntry{},
+		Providers: &BuiltinProviders{},
+	}
+
+	b := tl.ExportEnv()
+	assert.Equal(t, b, "#!/bin/sh\n")
+
+	tl = Teller{
+		Logger: getLogger(),
+		Entries: []core.EnvEntry{
+			{Key: "k", Value: `()"';@  \(\)\"\'\;\@`, ProviderName: "test-provider", ResolvedPath: "path/kv"},
+		},
+	}
+
+	b = tl.ExportEnv()
+	assert.Equal(t, b, "#!/bin/sh\nexport k='()\"'\"'\"';@  \\(\\)\\\"\\'\"'\"'\\;\\@'\n")
 }
 
 func TestTellerCollect(t *testing.T) {


### PR DESCRIPTION
## Related Issues
#131

## Description
For shell print export:
- Enclosing secret in single quote
- Support password with single quotes too

## Motivation and Context
Passwords containing special characters are now supported.

## How Has This Been Tested?
e2e + unit test + manual tests