### PR TITLE
GH-134: localstack compatibility for aws providers

### DIFF
--- a/pkg/providers/aws_secretsmanager.go
+++ b/pkg/providers/aws_secretsmanager.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
@@ -40,7 +42,7 @@ func init() {
 	metaInfo := core.MetaInfo{
 		Name:           "aws_secretsmanager",
 		Description:    "AWS Secrets Manager",
-		Authentication: "Your standard `AWS_DEFAULT_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` need to be populated in your environment",
+		Authentication: "Your standard `AWS_DEFAULT_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` need to be populated in your environment. `AWS_ENDPOINT` is used to allow usage of localstack",
 		ConfigTemplate: `
   # configure only from environment
   aws_secretsmanager:
@@ -57,7 +59,21 @@ func init() {
 }
 
 func NewAWSSecretsManager(logger logging.Logger) (core.Provider, error) {
-	cfg, err := config.LoadDefaultConfig(context.Background())
+	customResolver := aws.EndpointResolverFunc(func(service, region string) (aws.Endpoint, error) {
+		awsEndpointOverride := os.Getenv("AWS_ENDPOINT")
+		if awsEndpointOverride != "" {
+			return aws.Endpoint{
+				PartitionID:   "aws",
+				URL:           awsEndpointOverride,
+				SigningRegion: region,
+			}, nil
+		}
+
+		// returning EndpointNotFoundError will allow the service to fallback to its default resolution
+		return aws.Endpoint{}, &aws.EndpointNotFoundError{}
+	})
+
+	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithEndpointResolver(customResolver))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/providers/aws_ssm.go
+++ b/pkg/providers/aws_ssm.go
@@ -3,7 +3,9 @@ package providers
 import (
 	"context"
 	"fmt"
+	"os"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/spectralops/teller/pkg/core"
@@ -25,7 +27,7 @@ func init() {
 	metaInfo := core.MetaInfo{
 		Description:    "AWS SSM (aka paramstore)",
 		Name:           awsssmName,
-		Authentication: "Your standard `AWS_DEFAULT_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` need to be populated in your environment",
+		Authentication: "Your standard `AWS_DEFAULT_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` need to be populated in your environment. `AWS_ENDPOINT` is used to allow usage of localstack",
 		ConfigTemplate: `
   # configure only from environment
   aws_ssm:
@@ -40,7 +42,21 @@ func init() {
 }
 
 func NewAWSSSM(logger logging.Logger) (core.Provider, error) {
-	cfg, err := config.LoadDefaultConfig(context.TODO())
+	customResolver := aws.EndpointResolverFunc(func(service, region string) (aws.Endpoint, error) {
+		awsEndpointOverride := os.Getenv("AWS_ENDPOINT")
+		if awsEndpointOverride != "" {
+			return aws.Endpoint{
+				PartitionID:   "aws",
+				URL:           awsEndpointOverride,
+				SigningRegion: region,
+			}, nil
+		}
+
+		// returning EndpointNotFoundError will allow the service to fallback to its default resolution
+		return aws.Endpoint{}, &aws.EndpointNotFoundError{}
+	})
+
+	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithEndpointResolver(customResolver))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Related Issues
#134 

## Description
Add environment variable to allow custom aws endpoint for aws providers to work with localstack

## Motivation and Context
Allow developers to use services locally that we use for our deployed environments

## How Has This Been Tested?
Tested against localstack when `AWS_ENDPOINT` environment variable is set.
Tested against live aws when `AWS_ENDPOINT` environment variable is absent

# Checklist
- [x] Tests
- [x] Documentation
- [x] Linting: make files had issues locally 