### PR TITLE
Fix from merge 783dc56 to process_env provider

### DIFF
--- a/pkg/providers/process_env.go
+++ b/pkg/providers/process_env.go
@@ -31,7 +31,7 @@ func init() {
 `,
 		Ops: core.OpMatrix{Get: true, GetMapping: true, Put: false, PutMapping: false},
 	}
-	RegisterProvider(metaInto, NewConsul)
+	RegisterProvider(metaInto, NewProcessEnv)
 }
 
 // NewProcessEnv creates new provider instance


### PR DESCRIPTION
## Description

The last merge to master broke `process_env` provider, most likely a copy/paste error. 
Merge: https://github.com/tellerops/teller/commit/783dc56