### PR TITLE
substitute {{project}} with the project name

### DIFF
--- a/pkg/core/populate.go
+++ b/pkg/core/populate.go
@@ -40,21 +40,7 @@ func (p *Populate) FindAndReplace(path string) string {
 }
 
 func (p *Populate) KeyPath(kp KeyPath) KeyPath {
-	path := p.FindAndReplace(kp.Path)
-	populated := path
-	for k, v := range p.opts {
-		val := v
-		if strings.HasPrefix(v, populateFromEnvironment) {
-			evar := strings.TrimPrefix(v, populateFromEnvironment)
-			evar, defaultValue := p.parseDefaultValue(evar)
-			val = os.Getenv(evar)
-			if val == "" {
-				val = defaultValue
-			}
-		}
-		populated = strings.ReplaceAll(populated, fmt.Sprintf("{{%s}}", k), val)
-	}
-	return kp.SwitchPath(path)
+	return kp.SwitchPath(p.FindAndReplace(kp.Path))
 }
 
 // parseDefaultValue returns that field name and the default value if `populateWithDefault` was found

--- a/pkg/core/populate_test.go
+++ b/pkg/core/populate_test.go
@@ -8,9 +8,14 @@ import (
 )
 
 func TestPopulatePath(t *testing.T) {
-	p := NewPopulate(map[string]string{"foo": "bar", "teller-env": "env:TELLER_TEST_FOO", "teller-env-default": "env:TELLER_TEST_DEFAULT,default-value"})
-
 	os.Setenv("TELLER_TEST_FOO", "test-foo")
+
+	p := NewPopulate(map[string]string{
+		"foo":                "bar",
+		"teller-env":         "env:TELLER_TEST_FOO",
+		"teller-env-default": "env:TELLER_TEST_DEFAULT,default-value",
+	})
+
 	assert.Equal(t, p.FindAndReplace("foo/{{foo}}/qux/{{foo}}"), "foo/bar/qux/bar")
 	assert.Equal(t, p.FindAndReplace("foo/qux"), "foo/qux")
 	assert.Equal(t, p.FindAndReplace("foo/{{none}}"), "foo/{{none}}")
@@ -57,15 +62,11 @@ func TestPopulatePath(t *testing.T) {
 }
 
 func TestPopulateDefaultValue(t *testing.T) {
-
-	p := NewPopulate(map[string]string{})
-
-	key, value := p.parseDefaultValue("TELLER_TEST_FOO")
+	key, value := parseDefaultValue("TELLER_TEST_FOO")
 	assert.Equal(t, key, "TELLER_TEST_FOO")
 	assert.Equal(t, value, "")
 
-	key, value = p.parseDefaultValue("TELLER_TEST_FOO, default,,value")
+	key, value = parseDefaultValue("TELLER_TEST_FOO, default,,value")
 	assert.Equal(t, key, "TELLER_TEST_FOO")
 	assert.Equal(t, value, "default,,value")
-
 }

--- a/pkg/teller.go
+++ b/pkg/teller.go
@@ -44,12 +44,16 @@ type Teller struct {
 
 // Create a new Teller instance, using a tellerfile, and a command to execute (if any)
 func NewTeller(tlrfile *TellerFile, cmd []string, redact bool, logger logging.Logger) *Teller {
+	opts := core.Opts{"project": tlrfile.Project}
+	for k, v := range tlrfile.Opts {
+		opts[k] = v
+	}
 	return &Teller{
 		Redact:     redact,
 		Config:     tlrfile,
 		Cmd:        cmd,
 		Providers:  &BuiltinProviders{},
-		Populate:   core.NewPopulate(tlrfile.Opts),
+		Populate:   core.NewPopulate(opts),
 		Porcelain:  &Porcelain{Out: os.Stderr},
 		Templating: &Templating{},
 		Redactor:   &Redactor{},

--- a/pkg/teller_test.go
+++ b/pkg/teller_test.go
@@ -151,6 +151,28 @@ func getLogger() logging.Logger {
 	return logger
 }
 
+func TestNewTeller(t *testing.T) {
+	tlrfile := &TellerFile{
+		Project: "teller",
+		Opts: map[string]string{
+			"foo": "bar",
+		},
+	}
+	cmd := []string{"teller", "show"}
+	logger := getLogger()
+
+	tl := NewTeller(tlrfile, cmd, true, logger)
+
+	assert.True(t, tl.Redact)
+	assert.Equal(t, tl.Config, tlrfile)
+	assert.Equal(t, tl.Cmd, cmd)
+	assert.Equal(t, tl.Populate, core.NewPopulate(map[string]string{
+		"project": "teller",
+		"foo":     "bar",
+	}))
+	assert.Equal(t, tl.Logger, logger)
+}
+
 func TestTellerExports(t *testing.T) {
 	tl := Teller{
 		Logger:    getLogger(),


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
It'd be nice if `{{project}}` is substituted with the project name.


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We store secrets in etcd with the following path rule: `/{project name}/{stage}/{secret name}`, and thus our `.teller.yml` looks like this:

```yaml
project: some service
opts:
  project: some service
  stage: development

providers:
  etcd:
    env_sync:
      path: /{{project}}/{{stage}}/
```

It works, but `opts.project` is redundant because it's always the same as `project`. 

If `{{project}}` is substituted with the top-level `project` value, that'd be helpful.

This PR also refactors `core.Populate` so that it computes the substitution rules in advance. `Populate.KeyPath` is called multiple times, and it computes the same substitution rules. It's better to compute the rules only one time in the constructor.

I run a benchmark test with this PR (b837ac3150fabdb436c6504be59fffed2d27c585): 

```go
func BenchmarkPopulatePath(b *testing.B) {
	backup := os.Getenv("TELLER_TEST_FOO")
	defer os.Setenv("TELLER_TEST_FOO", backup)

	p := NewPopulate(map[string]string{
		"foo":                "bar",
		"teller-env":         "env:TELLER_TEST_FOO",
		"teller-env-default": "env:TELLER_TEST_DEFAULT,default-value",
	})
	os.Setenv("TELLER_TEST_FOO", "test-foo")

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		p.FindAndReplace("foo/{{foo}}/qux/{{foo}}")
		p.FindAndReplace("foo/qux")
		p.FindAndReplace("foo/{{none}}")
		p.FindAndReplace("foo/{{teller-env}}")
		p.FindAndReplace("foo/{{teller-env-default}}")
		p.FindAndReplace("")
	}
}
```

This is the result with the original implementation (before this PR):
```
goos: darwin
goarch: amd64
pkg: github.com/spectralops/teller/pkg/core
cpu: Intel(R) Core(TM) i7-8700B CPU @ 3.20GHz
BenchmarkPopulatePath
BenchmarkPopulatePath-12    	  290463	      4199 ns/op
```

and this is the result with this PR:
```
goos: darwin
goarch: amd64
pkg: github.com/spectralops/teller/pkg/core
cpu: Intel(R) Core(TM) i7-8700B CPU @ 3.20GHz
BenchmarkPopulatePath
BenchmarkPopulatePath-12    	 1597269	       733.3 ns/op
```


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
```
$ go test ./pkg/...
ok      github.com/spectralops/teller/pkg       2.483s
ok      github.com/spectralops/teller/pkg/core  (cached)
ok      github.com/spectralops/teller/pkg/logging       (cached)
ok      github.com/spectralops/teller/pkg/providers     (cached)
?       github.com/spectralops/teller/pkg/providers/mock_providers      [no test files]
?       github.com/spectralops/teller/pkg/utils [no test files]
```

# Checklist
- [x] Tests
- [ ] Documentation
- [x] Linting