### PR TITLE
Fix no redacted output until process ends

### DIFF
--- a/e2e/tests/redact.yml
+++ b/e2e/tests/redact.yml
@@ -1,0 +1,29 @@
+---
+name: redact input
+command: <binary-path> redact --in dirty
+config_file_name: .teller.yml
+config_content: >
+  project: redaction test
+
+  providers:
+    filesystem:
+      env:
+        FOO:
+          path: {{.Folder}}/settings/test/foo
+init_snapshot:
+  - path: settings/test
+    file_name: foo
+    content: secret
+  - path:
+    file_name: dirty
+    content: |
+      content
+      secret
+      content
+expected_snapshot:
+replace_stdout_content:
+expected_stdout: |
+  content
+  **REDACTED**
+  content
+expected_stderr:

--- a/e2e/tests/run-redact.yml
+++ b/e2e/tests/run-redact.yml
@@ -1,0 +1,33 @@
+---
+name: Run with --redact flag
+command: <binary-path> run --redact -- bash script
+config_file_name: .teller.yml
+config_content: >
+  project: redaction test
+
+  providers:
+    filesystem:
+      env:
+        FOO:
+          path: {{.Folder}}/settings/test/foo
+init_snapshot:
+  - path: settings/test
+    file_name: foo
+    content: secret
+  - path:
+    file_name: script
+    content: |
+      #!/usr/bin/env bash
+      for _ in {1..5};
+      do 
+        echo secret value;
+      done
+expected_snapshot:
+replace_stdout_content:
+expected_stdout: |
+  **REDACTED** value
+  **REDACTED** value
+  **REDACTED** value
+  **REDACTED** value
+  **REDACTED** value
+expected_stderr:

--- a/pkg/redactor.go
+++ b/pkg/redactor.go
@@ -1,6 +1,9 @@
 package pkg
 
 import (
+	"bufio"
+	"fmt"
+	"io"
 	"sort"
 	"strings"
 
@@ -8,24 +11,45 @@ import (
 )
 
 type Redactor struct {
-	Entries []core.EnvEntry
+	io.WriteCloser
+	err <-chan error
 }
 
-func NewRedactor(entries []core.EnvEntry) *Redactor {
-	return &Redactor{
-		Entries: entries,
-	}
-}
-
-func (r *Redactor) Redact(s string) string {
-	redacted := s
-	entries := append([]core.EnvEntry(nil), r.Entries...)
-
+func NewRedactor(dist io.Writer, entries []core.EnvEntry) *Redactor {
+	entries = append([]core.EnvEntry(nil), entries...)
 	sort.Sort(core.EntriesByValueSize(entries))
-	for i := range entries {
-		ent := entries[i]
-		redacted = strings.ReplaceAll(redacted, ent.Value, ent.RedactWith)
-	}
 
-	return redacted
+	r, w := io.Pipe()
+	ch := make(chan error)
+	go func() {
+		defer close(ch)
+
+		s := bufio.NewScanner(r)
+		buf := make([]byte, 0, 64*1024)
+		s.Buffer(buf, 10*1024*1024) // 10MB lines correlating to 10MB files max (bundles?)
+
+		for s.Scan() {
+			line := s.Text()
+			for _, ent := range entries {
+				line = strings.ReplaceAll(line, ent.Value, ent.RedactWith)
+			}
+			if _, err := fmt.Fprintln(dist, line); err != nil {
+				ch <- r.CloseWithError(err)
+				return
+			}
+		}
+		ch <- s.Err()
+	}()
+
+	return &Redactor{
+		WriteCloser: w,
+		err:         ch,
+	}
+}
+
+func (r *Redactor) Close() error {
+	err := r.WriteCloser.Close()
+	<-r.err
+
+	return err
 }

--- a/pkg/redactor_test.go
+++ b/pkg/redactor_test.go
@@ -1,6 +1,8 @@
 package pkg
 
 import (
+	"bytes"
+	"io"
 	"testing"
 
 	"github.com/alecthomas/assert"
@@ -8,12 +10,10 @@ import (
 )
 
 func TestRedactorOverlap(t *testing.T) {
-
 	// in this case we dont want '123' to appear in the clear after all redactions are made.
 	// it can happen if the smaller secret get replaced first because both
 	// secrets overlap. we need to ensure the wider secrets always get
 	// replaced first.
-
 	entries := []core.EnvEntry{
 		{
 			ProviderName: "test",
@@ -30,26 +30,33 @@ func TestRedactorOverlap(t *testing.T) {
 			RedactWith:   "**SOME_KEY**",
 		},
 	}
-	redactor := Redactor{Entries: entries}
 	s := `
-	func Foobar(){
-		secret := "hello"
-		callService(secret, "hello123")
-		// hello, hello123
-	}
-	`
+func Foobar(){
+	secret := "hello"
+	callService(secret, "hello123")
+	// hello, hello123
+}
+`
 	sr := `
-	func Foobar(){
-		secret := "**OTHER_KEY**"
-		callService(secret, "**SOME_KEY**")
-		// **OTHER_KEY**, **SOME_KEY**
-	}
-	`
+func Foobar(){
+	secret := "**OTHER_KEY**"
+	callService(secret, "**SOME_KEY**")
+	// **OTHER_KEY**, **SOME_KEY**
+}
+`
 
-	assert.Equal(t, redactor.Redact(s), sr)
+	buf := bytes.NewBuffer(nil)
+	redactor := NewRedactor(buf, entries)
+
+	_, err := io.WriteString(redactor, s)
+	assert.NoError(t, err)
+
+	err = redactor.Close()
+	assert.NoError(t, err)
+
+	assert.Equal(t, buf.String(), sr)
 }
 func TestRedactorMultiple(t *testing.T) {
-
 	entries := []core.EnvEntry{
 		{
 			ProviderName: "test",
@@ -66,25 +73,32 @@ func TestRedactorMultiple(t *testing.T) {
 			RedactWith:   "**OTHER_KEY**",
 		},
 	}
-	redactor := Redactor{Entries: entries}
 	s := `
-	func Foobar(){
-		secret := "loot"
-		callService(secret, "shazam")
-	}
-	`
+func Foobar(){
+	secret := "loot"
+	callService(secret, "shazam")
+}
+`
 	sr := `
-	func Foobar(){
-		secret := "**OTHER_KEY**"
-		callService(secret, "**SOME_KEY**")
-	}
-	`
+func Foobar(){
+	secret := "**OTHER_KEY**"
+	callService(secret, "**SOME_KEY**")
+}
+`
 
-	assert.Equal(t, redactor.Redact(s), sr)
+	buf := bytes.NewBuffer(nil)
+	redactor := NewRedactor(buf, entries)
+
+	_, err := io.WriteString(redactor, s)
+	assert.NoError(t, err)
+
+	err = redactor.Close()
+	assert.NoError(t, err)
+
+	assert.Equal(t, buf.String(), sr)
 }
 
 func TestRedactor(t *testing.T) {
-
 	entries := []core.EnvEntry{
 		{
 			ProviderName: "test",
@@ -94,19 +108,36 @@ func TestRedactor(t *testing.T) {
 			RedactWith:   "**NOPE**",
 		},
 	}
-	redactor := Redactor{Entries: entries}
 	s := `
-	func Foobar(){
-		secret := "shazam"
-		callService(secret, "shazam")
-	}
-	`
+func Foobar(){
+	secret := "shazam"
+	callService(secret, "shazam")
+}
+`
 	sr := `
-	func Foobar(){
-		secret := "**NOPE**"
-		callService(secret, "**NOPE**")
-	}
-	`
+func Foobar(){
+	secret := "**NOPE**"
+	callService(secret, "**NOPE**")
+}
+`
 
-	assert.Equal(t, redactor.Redact(s), sr)
+	buf := bytes.NewBuffer(nil)
+	redactor := NewRedactor(buf, entries)
+
+	_, err := io.WriteString(redactor, s)
+	assert.NoError(t, err)
+
+	err = redactor.Close()
+	assert.NoError(t, err)
+
+	assert.Equal(t, buf.String(), sr)
+}
+
+func TestRedactor_Close(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	redactor := NewRedactor(buf, nil)
+
+	assert.NoError(t, redactor.Close())
+	// can be close more than once.
+	assert.NoError(t, redactor.Close())
 }

--- a/pkg/redactor_test.go
+++ b/pkg/redactor_test.go
@@ -10,51 +10,96 @@ import (
 )
 
 func TestRedactorOverlap(t *testing.T) {
-	// in this case we dont want '123' to appear in the clear after all redactions are made.
-	// it can happen if the smaller secret get replaced first because both
-	// secrets overlap. we need to ensure the wider secrets always get
-	// replaced first.
-	entries := []core.EnvEntry{
+	cases := []struct {
+		name    string
+		entries []core.EnvEntry
+		s       string
+		sr      string
+	}{
 		{
-			ProviderName: "test",
-			ResolvedPath: "/some/path",
-			Key:          "OTHER_KEY",
-			Value:        "hello",
-			RedactWith:   "**OTHER_KEY**",
-		},
-		{
-			ProviderName: "test",
-			ResolvedPath: "/some/path",
-			Key:          "SOME_KEY",
-			Value:        "hello123",
-			RedactWith:   "**SOME_KEY**",
-		},
-	}
-	s := `
+			name: "overlap",
+			// in this case we don't want '123' to appear in the clear after all redactions are made.
+			// it can happen if the smaller secret get replaced first because both
+			// secrets overlap. we need to ensure the wider secrets always get
+			// replaced first.
+			entries: []core.EnvEntry{
+				{
+					ProviderName: "test",
+					ResolvedPath: "/some/path",
+					Key:          "OTHER_KEY",
+					Value:        "hello",
+					RedactWith:   "**OTHER_KEY**",
+				},
+				{
+					ProviderName: "test",
+					ResolvedPath: "/some/path",
+					Key:          "SOME_KEY",
+					Value:        "hello123",
+					RedactWith:   "**SOME_KEY**",
+				},
+			},
+			s: `
 func Foobar(){
 	secret := "hello"
 	callService(secret, "hello123")
 	// hello, hello123
 }
-`
-	sr := `
+`,
+			sr: `
 func Foobar(){
 	secret := "**OTHER_KEY**"
 	callService(secret, "**SOME_KEY**")
 	// **OTHER_KEY**, **SOME_KEY**
 }
-`
+`,
+		},
+		{
+			name: "multiple",
+			entries: []core.EnvEntry{
+				{
+					ProviderName: "test",
+					ResolvedPath: "/some/path",
+					Key:          "SOME_KEY",
+					Value:        "shazam",
+					RedactWith:   "**SOME_KEY**",
+				},
+				{
+					ProviderName: "test",
+					ResolvedPath: "/some/path",
+					Key:          "OTHER_KEY",
+					Value:        "loot",
+					RedactWith:   "**OTHER_KEY**",
+				},
+			},
+			s: `
+func Foobar(){
+	secret := "loot"
+	callService(secret, "shazam")
+}
+`,
+			sr: `
+func Foobar(){
+	secret := "**OTHER_KEY**"
+	callService(secret, "**SOME_KEY**")
+}
+`,
+		},
+	}
 
-	buf := bytes.NewBuffer(nil)
-	redactor := NewRedactor(buf, entries)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			buf := bytes.NewBuffer(nil)
+			redactor := NewRedactor(buf, c.entries)
 
-	_, err := io.WriteString(redactor, s)
-	assert.NoError(t, err)
+			_, err := io.WriteString(redactor, c.s)
+			assert.NoError(t, err)
 
-	err = redactor.Close()
-	assert.NoError(t, err)
+			err = redactor.Close()
+			assert.NoError(t, err)
 
-	assert.Equal(t, buf.String(), sr)
+			assert.Equal(t, buf.String(), c.sr)
+		})
+	}
 }
 func TestRedactorMultiple(t *testing.T) {
 	entries := []core.EnvEntry{

--- a/pkg/teller.go
+++ b/pkg/teller.go
@@ -38,7 +38,6 @@ type Teller struct {
 	Providers  Providers
 	Entries    []core.EnvEntry
 	Templating *Templating
-	Redactor   *Redactor
 	Logger     logging.Logger
 }
 
@@ -52,7 +51,6 @@ func NewTeller(tlrfile *TellerFile, cmd []string, redact bool, logger logging.Lo
 		Populate:   core.NewPopulate(tlrfile.Opts),
 		Porcelain:  &Porcelain{Out: os.Stderr},
 		Templating: &Templating{},
-		Redactor:   &Redactor{},
 		Logger:     logger,
 	}
 }
@@ -73,16 +71,20 @@ func (tl *Teller) execCmd(cmd string, cmdArgs []string, withRedaction bool) erro
 			os.Setenv(b.Key, b.Value)
 		}
 	}
-	if withRedaction {
-		out, err := command.CombinedOutput()
-		redacted := tl.Redactor.Redact(string(out))
-		os.Stdout.WriteString(redacted)
-		return err
-	}
 
 	command.Stdin = os.Stdin
 	command.Stdout = os.Stdout
 	command.Stderr = os.Stderr
+	if withRedaction {
+		o := NewRedactor(command.Stdout, tl.Entries)
+		defer o.Close()
+		command.Stdout = o
+
+		e := NewRedactor(command.Stderr, tl.Entries)
+		defer e.Close()
+		command.Stderr = e
+	}
+
 	return command.Run()
 }
 
@@ -178,23 +180,11 @@ func (tl *Teller) SetupNewProject(fname string) error {
 
 // Execute a command with teller. This requires all entries to be loaded beforehand with Collect()
 func (tl *Teller) RedactLines(r io.Reader, w io.Writer) error {
-	scanner := bufio.NewScanner(r)
-	//nolint
-	buf := make([]byte, 0, 64*1024)
-	//nolint
-	scanner.Buffer(buf, 10*1024*1024) // 10MB lines correlating to 10MB files max (bundles?)
+	o := NewRedactor(w, tl.Entries)
+	defer o.Close()
 
-	for scanner.Scan() {
-		if _, err := fmt.Fprintln(w, tl.Redactor.Redact(string(scanner.Bytes()))); err != nil {
-			return err
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return err
-	}
-
-	return nil
+	_, err := io.Copy(o, r)
+	return err
 }
 
 // Execute a command with teller. This requires all entries to be loaded beforehand with Collect()
@@ -482,7 +472,6 @@ func (tl *Teller) Collect() error {
 	}
 
 	tl.Entries = entries
-	tl.Redactor = NewRedactor(entries)
 	return nil
 }
 

--- a/pkg/teller_test.go
+++ b/pkg/teller_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -74,7 +75,7 @@ func (im *InMemProvider) Meta() core.MetaInfo {
 	return core.MetaInfo{}
 }
 
-//nolint
+// nolint
 func init() {
 	inmemProviderMeta := core.MetaInfo{
 		Name:        "inmem-provider",
@@ -636,4 +637,86 @@ func TestTellerDeleteAll(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, len(p.inmem), 0)
+}
+
+func TestTeller_execCmd(t *testing.T) {
+	cmd := "bash"
+	cmdArgs := []string{"-c", "for i in {1..3}; do echo $SOME_KEY; echo $OTHER_KEY 1>&2; done"}
+	entries := []core.EnvEntry{
+		{
+			ProviderName: "test",
+			ResolvedPath: "/some/path",
+			Key:          "OTHER_KEY",
+			Value:        "hello",
+			RedactWith:   "**OTHER_KEY**",
+		},
+		{
+			ProviderName: "test",
+			ResolvedPath: "/some/path",
+			Key:          "SOME_KEY",
+			Value:        "hello123",
+			RedactWith:   "**SOME_KEY**",
+		},
+	}
+
+	tests := []struct {
+		name          string
+		carryEnv      bool
+		withRedaction bool
+	}{
+		{
+			name:          "CarryEnv: false, withRedaction: false",
+			carryEnv:      false,
+			withRedaction: false,
+		},
+		{
+			name:          "CarryEnv: true, withRedaction: false",
+			carryEnv:      true,
+			withRedaction: false,
+		},
+		{
+			name:          "CarryEnv: false, withRedaction: true",
+			carryEnv:      false,
+			withRedaction: true,
+		},
+		{
+			name:          "CarryEnv: true, withRedaction: true",
+			carryEnv:      true,
+			withRedaction: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldStdout, oldStderr := os.Stdout, os.Stderr
+			t.Cleanup(func() {
+				os.Stdout, os.Stderr = oldStdout, oldStderr
+			})
+
+			var err error
+			os.Stdout, err = os.CreateTemp(t.TempDir(), "stdout")
+			assert.NoError(t, err)
+			os.Stderr, err = os.CreateTemp(t.TempDir(), "stderr")
+			assert.NoError(t, err)
+
+			tl := &Teller{
+				Config: &TellerFile{
+					CarryEnv: tt.carryEnv,
+				},
+				Entries: entries,
+			}
+			assert.NoError(t, tl.execCmd(cmd, cmdArgs, tt.withRedaction))
+
+			os.Stdout.Seek(0, io.SeekStart)
+			o, _ := io.ReadAll(os.Stdout)
+			os.Stderr.Seek(0, io.SeekStart)
+			e, _ := io.ReadAll(os.Stderr)
+			if tt.withRedaction {
+				assert.Equal(t, "**SOME_KEY**\n**SOME_KEY**\n**SOME_KEY**\n", string(o))
+				assert.Equal(t, "**OTHER_KEY**\n**OTHER_KEY**\n**OTHER_KEY**\n", string(e))
+			} else {
+				assert.Equal(t, "hello123\nhello123\nhello123\n", string(o))
+				assert.Equal(t, "hello\nhello\nhello\n", string(e))
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR fixes the issue that teller doesn’t output anything until the child process ends if  `--reduct` is given.

This issue happens because `Teller.execCmd` calls `CombinedOutput`, which keeps outputs on RAM until the child process ends:

https://github.com/tellerops/teller/blob/922b8919390989e33ef7366013eb122215eea25a/pkg/teller.go#L76-L81

If the child process ends soon, it won't be a problem. However, if the process is a long-running program such as a server, teller never outputs anything. What is worse, it'll use up RAM and be killed at some point, or panic with `ErrTooLarge` (see also https://pkg.go.dev/bytes#Buffer.Write).

This PR rewrites `Redactor` to work as an adapter of `io.Writable`. This implementation writes output immediately to stdout and stderr, and doesn't consume RAM.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

If we run this command

```shell
$ teller run --redact -- sh -c "while true; do echo value; sleep 1; done"
```

with this `.teller.yaml`

```yaml
project: teller redaction test
providers:
  dotenv:
    env:
      KEY:
        path: redaction_test.env
```

and this `redaction_test.env`

```.env
KEY=value
```

it only shows this message until the process is terminated

```
-*- teller: loaded variables for teller redaction test using .teller.yaml -*-
```

but it should output `**REDACTED**` every second.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

I ran the same command described above, i.e. `teller run --redact -- sh -c "while true; do echo value; sleep 1; done" ` and got this:

```
-*- teller: loaded variables for teller redaction test using .teller.yaml -*-
**REDACTED**
**REDACTED**
**REDACTED**
**REDACTED**
...
```

I also tried `redact` command and got this:

```
$ echo value | teller redact                                                     
**REDACTED**
```

# Checklist
- [x] Tests
- [ ] Documentation
- [x] Linting