### PR TITLE
Fix integration test

### DIFF
--- a/pkg/integration_test/consul_test.go
+++ b/pkg/integration_test/consul_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package integration_test
@@ -5,12 +6,12 @@ package integration_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/spectralops/teller/pkg/core"
+	"github.com/spectralops/teller/pkg/logging"
 	"github.com/spectralops/teller/pkg/providers"
 	"github.com/stretchr/testify/assert"
 	"github.com/testcontainers/testcontainers-go"
@@ -56,8 +57,8 @@ func TestGetConsul(t *testing.T) {
 	//
 	// use provider to read data
 	//
-	os.Setenv("CONSUL_HTTP_ADDR", host)
-	p, err := providers.NewConsul()
+	t.Setenv("CONSUL_HTTP_ADDR", host)
+	p, err := providers.NewConsul(logging.New())
 	assert.NoError(t, err)
 	kvp := core.KeyPath{Env: "MG_KEY", Path: "path/to/svc/MG_KEY"}
 	res, err := p.Get(kvp)

--- a/pkg/integration_test/dotenv_test.go
+++ b/pkg/integration_test/dotenv_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/spectralops/teller/pkg/core"
+	"github.com/spectralops/teller/pkg/logging"
 	"github.com/spectralops/teller/pkg/providers"
 	"github.com/stretchr/testify/assert"
 )
@@ -16,7 +17,7 @@ func TestGetDotEnv(t *testing.T) {
 	//
 	// pre-insert data
 	//
-	f, err := os.CreateTemp("", "dotenv-*")
+	f, err := os.CreateTemp(t.TempDir(), "dotenv-*")
 	assert.NoError(t, err)
 	f.WriteString("MG_KEY=123\n")
 	f.Close()
@@ -24,7 +25,7 @@ func TestGetDotEnv(t *testing.T) {
 	//
 	// use provider to read data
 	//
-	p, err := providers.NewDotenv()
+	p, err := providers.NewDotenv(logging.New())
 	assert.NoError(t, err)
 	kvp := core.KeyPath{Env: "MG_KEY", Path: f.Name()}
 	res, err := p.Get(kvp)

--- a/pkg/integration_test/etcd_test.go
+++ b/pkg/integration_test/etcd_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package integration_test
@@ -5,11 +6,11 @@ package integration_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/spectralops/teller/pkg/core"
+	"github.com/spectralops/teller/pkg/logging"
 	"github.com/spectralops/teller/pkg/providers"
 	"github.com/stretchr/testify/assert"
 	"github.com/testcontainers/testcontainers-go"
@@ -60,8 +61,8 @@ func TestGetEtcd(t *testing.T) {
 	//
 	// use provider to read data
 	//
-	os.Setenv("ETCDCTL_ENDPOINTS", host)
-	p, err := providers.NewEtcd()
+	t.Setenv("ETCDCTL_ENDPOINTS", host)
+	p, err := providers.NewEtcd(logging.New())
 	assert.NoError(t, err)
 	kvp := core.KeyPath{Env: "MG_KEY", Path: "path/to/svc/MG_KEY"}
 	res, err := p.Get(kvp)

--- a/pkg/integration_test/heroku_test.go
+++ b/pkg/integration_test/heroku_test.go
@@ -1,3 +1,4 @@
+//go:build integration_api
 // +build integration_api
 
 package integration_test
@@ -9,6 +10,7 @@ import (
 
 	heroku "github.com/heroku/heroku-go/v5"
 	"github.com/spectralops/teller/pkg/core"
+	"github.com/spectralops/teller/pkg/logging"
 	"github.com/spectralops/teller/pkg/providers"
 	"github.com/stretchr/testify/assert"
 )
@@ -35,7 +37,7 @@ func TestGetHeroku(t *testing.T) {
 	//
 	// use provider to read data
 	//
-	p, err := providers.NewHeroku()
+	p, err := providers.NewHeroku(logging.New())
 	assert.NoError(t, err)
 	kvp := core.KeyPath{Env: "MG_KEY", Path: "teller-heroku-integration"}
 	res, err := p.Get(kvp)

--- a/pkg/integration_test/vault_test.go
+++ b/pkg/integration_test/vault_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package integration_test
@@ -5,12 +6,12 @@ package integration_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/vault/api"
 	"github.com/spectralops/teller/pkg/core"
+	"github.com/spectralops/teller/pkg/logging"
 	"github.com/spectralops/teller/pkg/providers"
 	"github.com/stretchr/testify/assert"
 	"github.com/testcontainers/testcontainers-go"
@@ -60,9 +61,9 @@ func TestGetVaultSecret(t *testing.T) {
 	//
 	// use provider to read data
 	//
-	os.Setenv("VAULT_ADDR", host)
-	os.Setenv("VAULT_TOKEN", testToken)
-	p, err := providers.NewHashicorpVault()
+	t.Setenv("VAULT_ADDR", host)
+	t.Setenv("VAULT_TOKEN", testToken)
+	p, err := providers.NewHashicorpVault(logging.New())
 	assert.NoError(t, err)
 	kvp := core.KeyPath{Env: "MG_KEY", Path: "secret/data/settings/prod/billing-svc"}
 	res, err := p.Get(kvp)


### PR DESCRIPTION
## Description
`make integration_api` fails with this error message.

```
$ make integration_api
go test -v ./pkg/integration_test -cover -tags="integration_api integration"
# github.com/spectralops/teller/pkg/integration_test_test [github.com/spectralops/teller/pkg/integration_test.test]
pkg/integration_test/consul_test.go:60:12: not enough arguments in call to providers.NewConsul
        have ()
        want ("github.com/spectralops/teller/pkg/logging".Logger)
pkg/integration_test/dotenv_test.go:27:12: not enough arguments in call to providers.NewDotenv
        have ()
        want ("github.com/spectralops/teller/pkg/logging".Logger)
pkg/integration_test/etcd_test.go:64:12: not enough arguments in call to providers.NewEtcd
        have ()
        want ("github.com/spectralops/teller/pkg/logging".Logger)
pkg/integration_test/heroku_test.go:38:12: not enough arguments in call to providers.NewHeroku
        have ()
        want ("github.com/spectralops/teller/pkg/logging".Logger)
pkg/integration_test/vault_test.go:65:12: not enough arguments in call to providers.NewHashicorpVault
        have ()
        want ("github.com/spectralops/teller/pkg/logging".Logger)
FAIL    github.com/spectralops/teller/pkg/integration_test [build failed]
FAIL
make: *** [integration_api] Error 2
```

This PR fixes these errors. It also cleans up temporary files and environment variables. 


# Checklist
- [x] Tests
- [ ] Documentation
- [x] Linting