### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,15 @@ jobs:
 
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.45.0
           args: --timeout 5m0s

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18
 

--- a/.github/workflows/spectral.yaml
+++ b/.github/workflows/spectral.yaml
@@ -6,7 +6,7 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install Spectral
       uses: spectralops/spectral-github-action@v1
       with:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
CI tests for #159 fail, but it looks like golangci-lint-action has a problem. I run the CI tests with golangci-lint-action v3, and it passes. So, it's better to use the newest one. This PR updates actions.

# Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Linting