### PR TITLE
fallback default ''.teller.yml' to '.teller.yaml'

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,19 +1,20 @@
 package main
 
 import (
+	"errors"
 	"fmt"
-	"io"
-	"os"
-
 	"github.com/alecthomas/kong"
 	"github.com/spectralops/teller/pkg"
 	"github.com/spectralops/teller/pkg/logging"
 	"github.com/spectralops/teller/pkg/providers"
 	"github.com/spectralops/teller/pkg/utils"
+	"io"
+	"io/fs"
+	"os"
 )
 
 var CLI struct {
-	Config   string `short:"c" help:"Path to teller.yml"`
+	Config   string `short:"c" help:"Path to teller YAML file"`
 	LogLevel string `short:"l"  help:"Application log level"`
 
 	Run struct {
@@ -98,7 +99,7 @@ var (
 	defaultLogLevel = "error"
 )
 
-//nolint
+// nolint
 func main() {
 	ctx := kong.Parse(&CLI)
 
@@ -134,7 +135,14 @@ func main() {
 	//
 	// load or create new file
 	//
-	telleryml := ".teller.yml"
+	const (
+		defaultTellerFile = ".teller.yml"
+		// Alternative default teller file, it uses official YAML extension
+		// See https://github.com/tellerops/teller/issues/162
+		secondDefaultTellerFile = ".teller.yaml"
+	)
+
+	telleryml := defaultTellerFile
 	if CLI.Config != "" {
 		telleryml = CLI.Config
 	}
@@ -156,9 +164,11 @@ func main() {
 	}
 
 	tlrfile, err := pkg.NewTellerFile(telleryml)
+	if isDefaultFilePathErr(CLI.Config, err) {
+		tlrfile, err = pkg.NewTellerFile(secondDefaultTellerFile)
+	}
 	if err != nil {
 		logger.WithError(err).WithField("file", telleryml).Fatal("could not read file")
-
 	}
 
 	teller := pkg.NewTeller(tlrfile, CLI.Run.Cmd, CLI.Run.Redact, logger)
@@ -304,4 +314,12 @@ func main() {
 		println(ctx.Command())
 		teller.PrintEnvKeys()
 	}
+}
+
+func isDefaultFilePathErr(config string, err error) bool {
+	// Ignore if explicitly set to '.teller.yml'.
+	if config != "" {
+		return false
+	}
+	return errors.Is(err, fs.ErrNotExist)
 }

--- a/main.go
+++ b/main.go
@@ -3,14 +3,15 @@ package main
 import (
 	"errors"
 	"fmt"
+	"io"
+	"io/fs"
+	"os"
+
 	"github.com/alecthomas/kong"
 	"github.com/spectralops/teller/pkg"
 	"github.com/spectralops/teller/pkg/logging"
 	"github.com/spectralops/teller/pkg/providers"
 	"github.com/spectralops/teller/pkg/utils"
-	"io"
-	"io/fs"
-	"os"
 )
 
 var CLI struct {


### PR DESCRIPTION
https://github.com/tellerops/teller/issues/162

## Related Issues
<!-- - #[ISSUE-ID]-->
https://github.com/tellerops/teller/issues/162

## Description
<!-- Describe your changes in detail -->
In case, we use hardcoded default `.teller.yml` config and the file doesn't exist, try to find `.yaml` version.
In case, that the `.teller.yml` was set explicitly, won't. 

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
It's in the issue.
tl;dr: official YAML extenstion is `*.yaml`. Yet, for backward compatibility, we need to try `*.yml` first.
Some people, like me, can prefere `*.yaml` extension and don't want to set the config explicitly.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
I did manual testing. Really not sure how to do some unit testing in main func.
Yet the change is really straight forward.

# Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Linting