### PR TITLE
Fixed go get

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,11 +23,11 @@ brews:
   -
     name: teller
     tap:
-      owner: spectralops
+      owner: tellerops
       name: homebrew-tap
       token: "{{ .Env.GORELEASER_GITHUB_TOKEN }}"
     description: A secret manager for developers - never leave your terminal for secrets
-    homepage:  https://github.com/spectralops/teller
+    homepage:  https://github.com/tellerops/teller
     license: "Apache 2.0"
     install: |
       bin.install "teller"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 </p>
 
 <p align="center">
-<img src="https://github.com/spectralops/teller/actions/workflows/ci.yml/badge.svg"/>
+<img src="https://github.com/tellerops/teller/actions/workflows/ci.yml/badge.svg"/>
 
 </p>
 
@@ -39,7 +39,7 @@ You can use Teller to tidy your own environment or for your team as a process an
 You can install `teller` with homebrew:
 
 ```
-$ brew tap spectralops/tap && brew install teller
+$ brew tap tellerops/tap && brew install teller
 ```
 
 You can now use `teller` or `tlr` (if you like shortcuts!) in your terminal.
@@ -780,7 +780,7 @@ Requires an API key populated in your environment in: `VERCEL_TOKEN`.
 
 - Sync - `yes`
 - Mapping - `yes`
-- Modes - `read`, [write: accepting PR](https://github.com/spectralops/teller)
+- Modes - `read`, [write: accepting PR](https://github.com/tellerops/teller)
 - Key format
   - `env_sync` - name of your Vercel app
   - `env` - the actual env variable name in your Vercel settings
@@ -822,7 +822,7 @@ cert_file: ""
 
 ### Features
 
-- Sync - `no` [sync: accepting PR](https://github.com/spectralops/teller)
+- Sync - `no` [sync: accepting PR](https://github.com/tellerops/teller)
 - Mapping - `yes`
 - Modes - `read+write`
 - Key format
@@ -1296,7 +1296,7 @@ $ make lint
 
 ### Thanks:
 
-To all [Contributors](https://github.com/spectralops/teller/graphs/contributors) - you make this happen, thanks!
+To all [Contributors](https://github.com/tellerops/teller/graphs/contributors) - you make this happen, thanks!
 
 ### Code of conduct
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Teller Roadmap
 
-This document lists the new features being considered for the future and that are being experimented / worked on currently. We would like our contributors and users to know what features could come in the near future. We definitely welcome suggestions and ideas from everyone about the roadmap and features (feel free to open an [issue](https://github.com/SpectralOps/teller/issues)). 
+This document lists the new features being considered for the future and that are being experimented / worked on currently. We would like our contributors and users to know what features could come in the near future. We definitely welcome suggestions and ideas from everyone about the roadmap and features (feel free to open an [issue](https://github.com/tellerops/teller/issues)). 
 
 ## Currently worked on
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -10,10 +10,10 @@ import (
 
 	"testing"
 
-	"github.com/spectralops/teller/e2e/register"
-	_ "github.com/spectralops/teller/e2e/tests"
-	"github.com/spectralops/teller/e2e/testutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/tellerops/teller/e2e/register"
+	_ "github.com/tellerops/teller/e2e/tests"
+	"github.com/tellerops/teller/e2e/testutils"
 )
 
 const (

--- a/e2e/tests/version.go
+++ b/e2e/tests/version.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"regexp"
 
-	"github.com/spectralops/teller/e2e/register"
+	"github.com/tellerops/teller/e2e/register"
 )
 
 func init() { //nolint

--- a/examples/providers/example.go
+++ b/examples/providers/example.go
@@ -3,9 +3,9 @@ package providers
 import (
 	"fmt"
 
-	"github.com/spectralops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/core"
 
-	"github.com/spectralops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/logging"
 )
 
 type Example struct {

--- a/go.mod
+++ b/go.mod
@@ -130,7 +130,6 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
-	github.com/miekg/dns v1.1.35 // indirect
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
 	github.com/moby/sys/mount v0.2.0 // indirect
 	github.com/moby/sys/mountinfo v0.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/spectralops/teller
+module github.com/tellerops/teller
 
 go 1.18
 

--- a/go.sum
+++ b/go.sum
@@ -643,9 +643,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182aff
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+github.com/miekg/dns v1.1.26 h1:gPxPSwALAeHJSjarOs00QjVdV9QoBvc1D2ujQUr5BzU=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
-github.com/miekg/dns v1.1.35 h1:oTfOaDH+mZkdcgdIjH6yBajRGtIwcwcaR+rt23ZSrJs=
-github.com/miekg/dns v1.1.35/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
@@ -1199,7 +1198,6 @@ golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20191216052735-49a3e744a425/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20191216173652-a0e659d51361/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20191227053925-7b8e75db28f4/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200117161641-43d50277825c/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=

--- a/main.go
+++ b/main.go
@@ -8,10 +8,10 @@ import (
 	"os"
 
 	"github.com/alecthomas/kong"
-	"github.com/spectralops/teller/pkg"
-	"github.com/spectralops/teller/pkg/logging"
-	"github.com/spectralops/teller/pkg/providers"
-	"github.com/spectralops/teller/pkg/utils"
+	"github.com/tellerops/teller/pkg"
+	"github.com/tellerops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/providers"
+	"github.com/tellerops/teller/pkg/utils"
 )
 
 var CLI struct {

--- a/main.go
+++ b/main.go
@@ -111,7 +111,6 @@ func main() {
 	logger.SetLevel(defaultLogLevel)
 
 	// below commands don't require a tellerfile
-	//nolint
 	switch ctx.Command() {
 	case "version":
 		fmt.Printf("Teller %v\n", version)
@@ -231,9 +230,7 @@ func main() {
 		}
 		teller.Exec()
 
-	case "graph-drift <providers>":
-		fallthrough
-	case "graph-drift":
+	case "graph-drift <providers>", "graph-drift":
 		drifts := teller.Drift(CLI.GraphDrift.Providers)
 		if len(drifts) > 0 {
 			teller.Porcelain.PrintDrift(drifts)

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -3,7 +3,7 @@ package core
 import (
 	"strings"
 
-	"github.com/spectralops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/logging"
 )
 
 type Severity string

--- a/pkg/integration_test/consul_test.go
+++ b/pkg/integration_test/consul_test.go
@@ -10,10 +10,10 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/api"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
-	"github.com/spectralops/teller/pkg/providers"
 	"github.com/stretchr/testify/assert"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/providers"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 )

--- a/pkg/integration_test/dotenv_test.go
+++ b/pkg/integration_test/dotenv_test.go
@@ -7,10 +7,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
-	"github.com/spectralops/teller/pkg/providers"
 	"github.com/stretchr/testify/assert"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/providers"
 )
 
 func TestGetDotEnv(t *testing.T) {

--- a/pkg/integration_test/etcd_test.go
+++ b/pkg/integration_test/etcd_test.go
@@ -9,10 +9,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
-	"github.com/spectralops/teller/pkg/providers"
 	"github.com/stretchr/testify/assert"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/providers"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	clientv3 "go.etcd.io/etcd/client/v3"

--- a/pkg/integration_test/heroku_test.go
+++ b/pkg/integration_test/heroku_test.go
@@ -9,10 +9,10 @@ import (
 	"testing"
 
 	heroku "github.com/heroku/heroku-go/v5"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
-	"github.com/spectralops/teller/pkg/providers"
 	"github.com/stretchr/testify/assert"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/providers"
 )
 
 func TestGetHeroku(t *testing.T) {

--- a/pkg/integration_test/vault_test.go
+++ b/pkg/integration_test/vault_test.go
@@ -10,10 +10,10 @@ import (
 	"time"
 
 	"github.com/hashicorp/vault/api"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
-	"github.com/spectralops/teller/pkg/providers"
 	"github.com/stretchr/testify/assert"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/providers"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 )

--- a/pkg/porcelain.go
+++ b/pkg/porcelain.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/jftuga/ellipsis"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/utils"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/utils"
 )
 
 type Porcelain struct {

--- a/pkg/porcelain_test.go
+++ b/pkg/porcelain_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/alecthomas/assert"
-	"github.com/spectralops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/core"
 )
 
 func TestPorcelainNonInteractive(t *testing.T) {

--- a/pkg/providers.go
+++ b/pkg/providers.go
@@ -1,8 +1,8 @@
 package pkg
 
 import (
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/providers"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/providers"
 )
 
 type Providers interface {

--- a/pkg/providers/ansible_vault.go
+++ b/pkg/providers/ansible_vault.go
@@ -32,8 +32,7 @@ type AnsibleVault struct {
 	client AnsibleVaultClient
 }
 
-// nolint
-func init() {
+func init() { //nolint
 	metaInto := core.MetaInfo{
 		Description:    "Ansible Vault",
 		Name:           "ansible_vault",

--- a/pkg/providers/ansible_vault.go
+++ b/pkg/providers/ansible_vault.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/joho/godotenv"
 	vault "github.com/sosedoff/ansible-vault-go"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
 )
 
 type AnsibleVaultClient interface {
@@ -32,7 +32,7 @@ type AnsibleVault struct {
 	client AnsibleVaultClient
 }
 
-//nolint
+// nolint
 func init() {
 	metaInto := core.MetaInfo{
 		Description:    "Ansible Vault",

--- a/pkg/providers/ansible_vault_test.go
+++ b/pkg/providers/ansible_vault_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/spectralops/teller/pkg/providers/mock_providers"
+	"github.com/tellerops/teller/pkg/providers/mock_providers"
 )
 
 func TestAnsibleVault(t *testing.T) {

--- a/pkg/providers/aws_secretsmanager.go
+++ b/pkg/providers/aws_secretsmanager.go
@@ -13,9 +13,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
-	"github.com/spectralops/teller/pkg/utils"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/utils"
 )
 
 type AWSSecretsManagerClient interface {
@@ -38,7 +38,7 @@ var defaultDeletionRecoveryWindowInDays int64 = 7
 
 const versionSplit = ","
 
-//nolint
+// nolint
 func init() {
 	metaInfo := core.MetaInfo{
 		Name:           "aws_secretsmanager",

--- a/pkg/providers/aws_secretsmanager.go
+++ b/pkg/providers/aws_secretsmanager.go
@@ -38,8 +38,7 @@ var defaultDeletionRecoveryWindowInDays int64 = 7
 
 const versionSplit = ","
 
-// nolint
-func init() {
+func init() { //nolint
 	metaInfo := core.MetaInfo{
 		Name:           "aws_secretsmanager",
 		Description:    "AWS Secrets Manager",

--- a/pkg/providers/aws_secretsmanager_test.go
+++ b/pkg/providers/aws_secretsmanager_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/golang/mock/gomock"
 
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/providers/mock_providers"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/providers/mock_providers"
 )
 
 func TestAWSSecretsManager(t *testing.T) {

--- a/pkg/providers/aws_ssm.go
+++ b/pkg/providers/aws_ssm.go
@@ -9,8 +9,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
 )
 
 type AWSSSMClient interface {
@@ -25,7 +25,7 @@ type AWSSSM struct {
 
 const awsssmName = "aws_ssm"
 
-//nolint
+// nolint
 func init() {
 	metaInfo := core.MetaInfo{
 		Description:    "AWS SSM (aka paramstore)",

--- a/pkg/providers/aws_ssm.go
+++ b/pkg/providers/aws_ssm.go
@@ -25,8 +25,7 @@ type AWSSSM struct {
 
 const awsssmName = "aws_ssm"
 
-// nolint
-func init() {
+func init() { //nolint
 	metaInfo := core.MetaInfo{
 		Description:    "AWS SSM (aka paramstore)",
 		Name:           awsssmName,

--- a/pkg/providers/aws_ssm_test.go
+++ b/pkg/providers/aws_ssm_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/golang/mock/gomock"
 
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/providers/mock_providers"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/providers/mock_providers"
 )
 
 func TestAWSSSM(t *testing.T) {

--- a/pkg/providers/azure_keyvault.go
+++ b/pkg/providers/azure_keyvault.go
@@ -9,8 +9,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/keyvault/keyvault"
 	kvauth "github.com/Azure/azure-sdk-for-go/services/keyvault/auth"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
 )
 
 const AzureVaultDomain = "vault.azure.net"
@@ -31,7 +31,7 @@ type AzureKeyVault struct {
 
 const azureName = "azure_keyvault"
 
-//nolint
+// nolint
 func init() {
 	metaInfo := core.MetaInfo{
 		Description:    "Azure Key Vault",

--- a/pkg/providers/azure_keyvault.go
+++ b/pkg/providers/azure_keyvault.go
@@ -31,8 +31,7 @@ type AzureKeyVault struct {
 
 const azureName = "azure_keyvault"
 
-// nolint
-func init() {
+func init() { //nolint
 	metaInfo := core.MetaInfo{
 		Description:    "Azure Key Vault",
 		Name:           azureName,

--- a/pkg/providers/azure_keyvault_test.go
+++ b/pkg/providers/azure_keyvault_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/alecthomas/assert"
 	"github.com/golang/mock/gomock"
 
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/providers/mock_providers"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/providers/mock_providers"
 )
 
 func String(v string) *string { return &v }

--- a/pkg/providers/cloudflare_workers_kv.go
+++ b/pkg/providers/cloudflare_workers_kv.go
@@ -25,8 +25,7 @@ type Cloudflare struct {
 
 const cloudFlareWorkersKVName = "cloudflare_workers_kv"
 
-// nolint
-func init() {
+func init() { //nolint
 	metaInfo := core.MetaInfo{
 		Description:    "Cloudflare Workers K/V",
 		Name:           cloudFlareWorkersKVName,

--- a/pkg/providers/cloudflare_workers_kv.go
+++ b/pkg/providers/cloudflare_workers_kv.go
@@ -7,8 +7,8 @@ import (
 	"sort"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
 )
 
 type CloudflareClient interface {
@@ -25,7 +25,7 @@ type Cloudflare struct {
 
 const cloudFlareWorkersKVName = "cloudflare_workers_kv"
 
-//nolint
+// nolint
 func init() {
 	metaInfo := core.MetaInfo{
 		Description:    "Cloudflare Workers K/V",

--- a/pkg/providers/cloudflare_workers_kv_test.go
+++ b/pkg/providers/cloudflare_workers_kv_test.go
@@ -8,8 +8,8 @@ import (
 	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/golang/mock/gomock"
 
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/providers/mock_providers"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/providers/mock_providers"
 )
 
 func TestCloudflareWorkersKV(t *testing.T) {

--- a/pkg/providers/cloudflare_workers_secrets.go
+++ b/pkg/providers/cloudflare_workers_secrets.go
@@ -7,8 +7,8 @@ import (
 	"os"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
 )
 
 var (
@@ -27,7 +27,7 @@ type CloudflareSecrets struct {
 
 const CloudflareWorkersSecretName = "cloudflare_workers_secret"
 
-//nolint
+// nolint
 func init() {
 	metaInfo := core.MetaInfo{
 		Description:    "Cloudflare Workers Secrets",

--- a/pkg/providers/cloudflare_workers_secrets.go
+++ b/pkg/providers/cloudflare_workers_secrets.go
@@ -27,8 +27,7 @@ type CloudflareSecrets struct {
 
 const CloudflareWorkersSecretName = "cloudflare_workers_secret"
 
-// nolint
-func init() {
+func init() { //nolint
 	metaInfo := core.MetaInfo{
 		Description:    "Cloudflare Workers Secrets",
 		Name:           CloudflareWorkersSecretName,

--- a/pkg/providers/cloudflare_workers_secrets_test.go
+++ b/pkg/providers/cloudflare_workers_secrets_test.go
@@ -7,8 +7,8 @@ import (
 	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/golang/mock/gomock"
 
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/providers/mock_providers"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/providers/mock_providers"
 )
 
 func TestCloudflareWorkersSecretsPut(t *testing.T) {

--- a/pkg/providers/consul.go
+++ b/pkg/providers/consul.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/hashicorp/consul/api"
 
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
-	"github.com/spectralops/teller/pkg/utils"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/utils"
 )
 
 type ConsulClient interface {
@@ -24,7 +24,7 @@ type Consul struct {
 
 const consulName = "consul"
 
-//nolint
+// nolint
 func init() {
 	metaInto := core.MetaInfo{
 		Description:    "Consul",

--- a/pkg/providers/consul.go
+++ b/pkg/providers/consul.go
@@ -24,8 +24,7 @@ type Consul struct {
 
 const consulName = "consul"
 
-// nolint
-func init() {
+func init() { //nolint
 	metaInto := core.MetaInfo{
 		Description:    "Consul",
 		Name:           consulName,

--- a/pkg/providers/consul_test.go
+++ b/pkg/providers/consul_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/hashicorp/consul/api"
 
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/providers/mock_providers"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/providers/mock_providers"
 )
 
 func TestConsul(t *testing.T) {

--- a/pkg/providers/cyberark_conjur.go
+++ b/pkg/providers/cyberark_conjur.go
@@ -29,8 +29,7 @@ type CyberArkConjur struct {
 
 const ConjurName = "cyberark_conjur"
 
-// nolint
-func init() {
+func init() { //nolint
 	metaInfo := core.MetaInfo{
 		Description:    "CyberArk Conjure",
 		Name:           ConjurName,

--- a/pkg/providers/cyberark_conjur.go
+++ b/pkg/providers/cyberark_conjur.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/cyberark/conjur-api-go/conjurapi"
 	"github.com/cyberark/conjur-api-go/conjurapi/authn"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
 )
 
 type ResourceFilter struct {
@@ -29,7 +29,7 @@ type CyberArkConjur struct {
 
 const ConjurName = "cyberark_conjur"
 
-//nolint
+// nolint
 func init() {
 	metaInfo := core.MetaInfo{
 		Description:    "CyberArk Conjure",

--- a/pkg/providers/doppler.go
+++ b/pkg/providers/doppler.go
@@ -10,8 +10,8 @@ import (
 	"github.com/DopplerHQ/cli/pkg/http"
 	"github.com/DopplerHQ/cli/pkg/models"
 	"github.com/DopplerHQ/cli/pkg/utils"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
 )
 
 type DopplerClient interface {
@@ -32,7 +32,7 @@ type Doppler struct {
 
 const DopplerName = "doppler"
 
-//nolint
+// nolint
 func init() {
 	metaInfo := core.MetaInfo{
 		Description: "Doppler",

--- a/pkg/providers/doppler.go
+++ b/pkg/providers/doppler.go
@@ -32,8 +32,7 @@ type Doppler struct {
 
 const DopplerName = "doppler"
 
-// nolint
-func init() {
+func init() { //nolint
 	metaInfo := core.MetaInfo{
 		Description: "Doppler",
 		Name:        DopplerName,

--- a/pkg/providers/doppler_test.go
+++ b/pkg/providers/doppler_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/DopplerHQ/cli/pkg/http"
 	"github.com/DopplerHQ/cli/pkg/models"
 	"github.com/golang/mock/gomock"
-	"github.com/spectralops/teller/pkg/providers/mock_providers"
+	"github.com/tellerops/teller/pkg/providers/mock_providers"
 )
 
 func TestDoppler(t *testing.T) {

--- a/pkg/providers/dotenv.go
+++ b/pkg/providers/dotenv.go
@@ -96,8 +96,7 @@ type Dotenv struct {
 	logger logging.Logger
 }
 
-// nolint
-func init() {
+func init() { //nolint
 	metaInfo := core.MetaInfo{
 		Description:    ".env",
 		Authentication: "",

--- a/pkg/providers/dotenv.go
+++ b/pkg/providers/dotenv.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/joho/godotenv"
 	"github.com/mitchellh/go-homedir"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
-	"github.com/spectralops/teller/pkg/utils"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/utils"
 )
 
 const (
@@ -96,7 +96,7 @@ type Dotenv struct {
 	logger logging.Logger
 }
 
-//nolint
+// nolint
 func init() {
 	metaInfo := core.MetaInfo{
 		Description:    ".env",

--- a/pkg/providers/dotenv_test.go
+++ b/pkg/providers/dotenv_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/alecthomas/assert"
 	"github.com/golang/mock/gomock"
 
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/providers/mock_providers"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/providers/mock_providers"
 )
 
 func TestDotenv(t *testing.T) {

--- a/pkg/providers/etcd.go
+++ b/pkg/providers/etcd.go
@@ -31,8 +31,7 @@ type Etcd struct {
 
 const EtcdName = "etcd"
 
-// nolint
-func init() {
+func init() { //nolint
 	metaInfo := core.MetaInfo{
 		Description:    "Etcd",
 		Name:           EtcdName,

--- a/pkg/providers/etcd.go
+++ b/pkg/providers/etcd.go
@@ -15,9 +15,9 @@ import (
 	"go.etcd.io/etcd/pkg/v3/transport"
 
 	"github.com/samber/lo"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
-	"github.com/spectralops/teller/pkg/utils"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/utils"
 )
 
 type EtcdClient interface {
@@ -31,7 +31,7 @@ type Etcd struct {
 
 const EtcdName = "etcd"
 
-//nolint
+// nolint
 func init() {
 	metaInfo := core.MetaInfo{
 		Description:    "Etcd",

--- a/pkg/providers/etcd_test.go
+++ b/pkg/providers/etcd_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/alecthomas/assert"
 	"github.com/golang/mock/gomock"
 
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/providers/mock_providers"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/providers/mock_providers"
 	spb "go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
 )

--- a/pkg/providers/export.go
+++ b/pkg/providers/export.go
@@ -3,7 +3,7 @@ package providers
 import (
 	"encoding/json"
 
-	"github.com/spectralops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/core"
 )
 
 type TellerExport struct {

--- a/pkg/providers/export_test.go
+++ b/pkg/providers/export_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/alecthomas/assert"
-	"github.com/spectralops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/core"
 )
 
 func TestGenerateProvidersMetaJSON(t *testing.T) {

--- a/pkg/providers/filesystem.go
+++ b/pkg/providers/filesystem.go
@@ -22,8 +22,7 @@ type FileSystem struct {
 
 const FileSystemName = "FileSystem"
 
-// nolint
-func init() {
+func init() { //nolint
 	metaInfo := core.MetaInfo{
 		Description:    "File system",
 		Name:           FileSystemName,

--- a/pkg/providers/filesystem.go
+++ b/pkg/providers/filesystem.go
@@ -11,8 +11,8 @@ import (
 	"unicode/utf8"
 
 	"github.com/karrick/godirwalk"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
 )
 
 type FileSystem struct {
@@ -22,7 +22,7 @@ type FileSystem struct {
 
 const FileSystemName = "FileSystem"
 
-//nolint
+// nolint
 func init() {
 	metaInfo := core.MetaInfo{
 		Description:    "File system",

--- a/pkg/providers/filesystem_test.go
+++ b/pkg/providers/filesystem_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/alecthomas/assert"
-	"github.com/spectralops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/core"
 )
 
 func createMockDirectoryStructure(f *FileSystem) error {

--- a/pkg/providers/github.go
+++ b/pkg/providers/github.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 
 	"github.com/google/go-github/v43/github"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
 	"golang.org/x/crypto/nacl/box"
 	"golang.org/x/oauth2"
 )
@@ -36,7 +36,7 @@ type GitHub struct {
 // NewGitHub create new GitHub provider
 const GithubName = "GitHub"
 
-//nolint
+// nolint
 func init() {
 	metaInfo := core.MetaInfo{
 		Description:    "Github",

--- a/pkg/providers/github.go
+++ b/pkg/providers/github.go
@@ -36,8 +36,7 @@ type GitHub struct {
 // NewGitHub create new GitHub provider
 const GithubName = "GitHub"
 
-// nolint
-func init() {
+func init() { //nolint
 	metaInfo := core.MetaInfo{
 		Description:    "Github",
 		Authentication: "Requires `GITHUB_AUTH_TOKEN`",

--- a/pkg/providers/github_test.go
+++ b/pkg/providers/github_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-github/v43/github"
 
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/providers/mock_providers"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/providers/mock_providers"
 )
 
 func TestGitHubPut(t *testing.T) {

--- a/pkg/providers/google_secretmanager.go
+++ b/pkg/providers/google_secretmanager.go
@@ -12,8 +12,8 @@ import (
 	secretmanagerpb "google.golang.org/genproto/googleapis/cloud/secretmanager/v1"
 
 	"github.com/googleapis/gax-go/v2"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
 	"google.golang.org/api/iterator"
 )
 
@@ -30,7 +30,7 @@ type GoogleSecretManager struct {
 
 const GoogleSecretManagerName = "google_secretmanager"
 
-//nolint
+// nolint
 func init() {
 	metaInfo := core.MetaInfo{
 		Description:    "Google Secret Manager",

--- a/pkg/providers/google_secretmanager.go
+++ b/pkg/providers/google_secretmanager.go
@@ -30,8 +30,7 @@ type GoogleSecretManager struct {
 
 const GoogleSecretManagerName = "google_secretmanager"
 
-// nolint
-func init() {
+func init() { //nolint
 	metaInfo := core.MetaInfo{
 		Description:    "Google Secret Manager",
 		Name:           GoogleSecretManagerName,

--- a/pkg/providers/google_secretmanager_test.go
+++ b/pkg/providers/google_secretmanager_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/golang/mock/gomock"
 	secretmanagerpb "google.golang.org/genproto/googleapis/cloud/secretmanager/v1"
 
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/providers/mock_providers"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/providers/mock_providers"
 )
 
 func TestGoogleSM(t *testing.T) {

--- a/pkg/providers/gopass.go
+++ b/pkg/providers/gopass.go
@@ -26,8 +26,7 @@ type Gopass struct {
 
 const GoPassName = "gopass"
 
-// nolint
-func init() {
+func init() { //nolint
 	metaInfo := core.MetaInfo{
 		Description:    "Gopass",
 		Name:           GoPassName,

--- a/pkg/providers/gopass.go
+++ b/pkg/providers/gopass.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/gopasspw/gopass/pkg/gopass"
 	"github.com/gopasspw/gopass/pkg/gopass/api"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
-	"github.com/spectralops/teller/pkg/utils"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/utils"
 )
 
 type GopassClient interface {
@@ -26,7 +26,7 @@ type Gopass struct {
 
 const GoPassName = "gopass"
 
-//nolint
+// nolint
 func init() {
 	metaInfo := core.MetaInfo{
 		Description:    "Gopass",

--- a/pkg/providers/gopass_test.go
+++ b/pkg/providers/gopass_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/gopasspw/gopass/pkg/gopass/secrets/secparse"
 
 	// "github.com/gopasspw/gopass/pkg/gopass/secrets/secparse"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/providers/mock_providers"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/providers/mock_providers"
 )
 
 func TestGopass(t *testing.T) {

--- a/pkg/providers/hashicorp_vault.go
+++ b/pkg/providers/hashicorp_vault.go
@@ -20,8 +20,7 @@ type HashicorpVault struct {
 
 const HashicorpVaultName = "hashicorp_vault"
 
-// nolint
-func init() {
+func init() { //nolint
 	metaInfo := core.MetaInfo{
 		Description:    "Hashicorp Vault",
 		Name:           HashicorpVaultName,

--- a/pkg/providers/hashicorp_vault.go
+++ b/pkg/providers/hashicorp_vault.go
@@ -5,8 +5,8 @@ import (
 	"sort"
 
 	"github.com/hashicorp/vault/api"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
 )
 
 type HashicorpClient interface {
@@ -20,7 +20,7 @@ type HashicorpVault struct {
 
 const HashicorpVaultName = "hashicorp_vault"
 
-//nolint
+// nolint
 func init() {
 	metaInfo := core.MetaInfo{
 		Description:    "Hashicorp Vault",

--- a/pkg/providers/hashicorp_vault_test.go
+++ b/pkg/providers/hashicorp_vault_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/golang/mock/gomock"
 
 	"github.com/hashicorp/vault/api"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/providers/mock_providers"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/providers/mock_providers"
 )
 
 func TestHashicorpVault(t *testing.T) {

--- a/pkg/providers/helpers_test.go
+++ b/pkg/providers/helpers_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/alecthomas/assert"
 
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
 )
 
 func AssertProvider(t *testing.T, s core.Provider, sync bool) {

--- a/pkg/providers/heroku.go
+++ b/pkg/providers/heroku.go
@@ -7,8 +7,8 @@ import (
 	"sort"
 
 	heroku "github.com/heroku/heroku-go/v5"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
 )
 
 type HerokuClient interface {
@@ -22,7 +22,7 @@ type Heroku struct {
 
 const HerokuName = "heroku"
 
-//nolint
+// nolint
 func init() {
 	metaInfo := core.MetaInfo{
 		Description:    "Heroku",

--- a/pkg/providers/heroku.go
+++ b/pkg/providers/heroku.go
@@ -22,8 +22,7 @@ type Heroku struct {
 
 const HerokuName = "heroku"
 
-// nolint
-func init() {
+func init() { //nolint
 	metaInfo := core.MetaInfo{
 		Description:    "Heroku",
 		Name:           HerokuName,

--- a/pkg/providers/heroku_test.go
+++ b/pkg/providers/heroku_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/alecthomas/assert"
 	"github.com/golang/mock/gomock"
 
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/providers/mock_providers"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/providers/mock_providers"
 )
 
 func TestHeroku(t *testing.T) {

--- a/pkg/providers/keeper_secretsmanager.go
+++ b/pkg/providers/keeper_secretsmanager.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 
 	ksm "github.com/keeper-security/secrets-manager-go/core"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
 )
 
 type KsmClient interface {
@@ -24,8 +24,7 @@ type KeeperSecretsManager struct {
 
 const keeperName = "keeper_secretsmanager"
 
-//nolint
-func init() {
+func init() { //nolint
 	metaInto := core.MetaInfo{
 		Description:    "Keeper Secrets Manager",
 		Name:           keeperName,

--- a/pkg/providers/keeper_secretsmanager_test.go
+++ b/pkg/providers/keeper_secretsmanager_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/alecthomas/assert"
 	"github.com/golang/mock/gomock"
 
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/providers/mock_providers"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/providers/mock_providers"
 )
 
 func TestKeeperSecretsManager(t *testing.T) {

--- a/pkg/providers/keypass.go
+++ b/pkg/providers/keypass.go
@@ -24,8 +24,7 @@ type KeyPass struct {
 
 const KeyPassName = "KeyPass"
 
-// nolint
-func init() {
+func init() { //nolint
 	metaInfo := core.MetaInfo{
 		Description:    "Keypass",
 		Name:           KeyPassName,

--- a/pkg/providers/keypass.go
+++ b/pkg/providers/keypass.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spectralops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/core"
 
-	"github.com/spectralops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/logging"
 	"github.com/tobischo/gokeepasslib/v3"
 )
 
@@ -24,7 +24,7 @@ type KeyPass struct {
 
 const KeyPassName = "KeyPass"
 
-//nolint
+// nolint
 func init() {
 	metaInfo := core.MetaInfo{
 		Description:    "Keypass",

--- a/pkg/providers/keypass_test.go
+++ b/pkg/providers/keypass_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/alecthomas/assert"
-	"github.com/spectralops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/core"
 )
 
 func TestKetPass(t *testing.T) {

--- a/pkg/providers/lastpass.go
+++ b/pkg/providers/lastpass.go
@@ -24,8 +24,7 @@ type LastPass struct {
 
 const LastPassName = "lastpass"
 
-// nolint
-func init() {
+func init() { //nolint
 	metaInfo := core.MetaInfo{
 		Description:    "Lastpass",
 		Authentication: "TODO(XXX)",

--- a/pkg/providers/lastpass.go
+++ b/pkg/providers/lastpass.go
@@ -7,10 +7,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spectralops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/core"
 
 	"github.com/mattn/lastpass-go"
-	"github.com/spectralops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/logging"
 )
 
 const (
@@ -24,7 +24,7 @@ type LastPass struct {
 
 const LastPassName = "lastpass"
 
-//nolint
+// nolint
 func init() {
 	metaInfo := core.MetaInfo{
 		Description:    "Lastpass",

--- a/pkg/providers/lastpass_test.go
+++ b/pkg/providers/lastpass_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/alecthomas/assert"
 	"github.com/mattn/lastpass-go"
-	"github.com/spectralops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/core"
 )
 
 func TestLastPass(t *testing.T) {

--- a/pkg/providers/mock_providers/keeper_secretsmanager_mock.go
+++ b/pkg/providers/mock_providers/keeper_secretsmanager_mock.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	core "github.com/spectralops/teller/pkg/core"
+	core "github.com/tellerops/teller/pkg/core"
 )
 
 // MockKsmClient is a mock of KsmClient interface.

--- a/pkg/providers/onepassword.go
+++ b/pkg/providers/onepassword.go
@@ -21,8 +21,7 @@ type OnePassword struct {
 
 const OnePasswordName = "1password"
 
-// nolint
-func init() {
+func init() { //nolint
 	metaInfo := core.MetaInfo{
 		Description: "1Password",
 		Name:        OnePasswordName,

--- a/pkg/providers/onepassword.go
+++ b/pkg/providers/onepassword.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/1Password/connect-sdk-go/connect"
 	"github.com/1Password/connect-sdk-go/onepassword"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
 )
 
 type OnePasswordClient interface {
@@ -21,7 +21,7 @@ type OnePassword struct {
 
 const OnePasswordName = "1password"
 
-//nolint
+// nolint
 func init() {
 	metaInfo := core.MetaInfo{
 		Description: "1Password",

--- a/pkg/providers/onepassword_test.go
+++ b/pkg/providers/onepassword_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/golang/mock/gomock"
 
 	"github.com/1Password/connect-sdk-go/onepassword"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/providers/mock_providers"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/providers/mock_providers"
 )
 
 func TestOnePassword(t *testing.T) {

--- a/pkg/providers/process_env.go
+++ b/pkg/providers/process_env.go
@@ -15,8 +15,7 @@ type ProcessEnv struct {
 	logger logging.Logger
 }
 
-// nolint
-func init() {
+func init() { //nolint
 	metaInto := core.MetaInfo{
 		Description:    "ProcessEnv",
 		Name:           "process_env",

--- a/pkg/providers/process_env.go
+++ b/pkg/providers/process_env.go
@@ -6,16 +6,16 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/spectralops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/core"
 
-	"github.com/spectralops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/logging"
 )
 
 type ProcessEnv struct {
 	logger logging.Logger
 }
 
-//nolint
+// nolint
 func init() {
 	metaInto := core.MetaInfo{
 		Description:    "ProcessEnv",

--- a/pkg/providers/register.go
+++ b/pkg/providers/register.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
 )
 
 var providersMap = map[string]core.RegisteredProvider{}

--- a/pkg/providers/vercel.go
+++ b/pkg/providers/vercel.go
@@ -6,8 +6,8 @@ import (
 	"sort"
 
 	"github.com/dghubble/sling"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
 )
 
 type VercelClient interface {
@@ -65,7 +65,7 @@ const ProjectEndPoint = "/projects"
 
 const VercelName = "vercel"
 
-//nolint
+// nolint
 func init() {
 	metaInfo := core.MetaInfo{
 		Name:           "vercel",

--- a/pkg/providers/vercel.go
+++ b/pkg/providers/vercel.go
@@ -65,8 +65,7 @@ const ProjectEndPoint = "/projects"
 
 const VercelName = "vercel"
 
-// nolint
-func init() {
+func init() { //nolint
 	metaInfo := core.MetaInfo{
 		Name:           "vercel",
 		Description:    "Vercel",

--- a/pkg/providers/vercel_test.go
+++ b/pkg/providers/vercel_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/alecthomas/assert"
 	"github.com/golang/mock/gomock"
 
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/providers/mock_providers"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/providers/mock_providers"
 )
 
 func TestVercel(t *testing.T) {

--- a/pkg/redactor.go
+++ b/pkg/redactor.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/spectralops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/core"
 )
 
 const (

--- a/pkg/redactor_test.go
+++ b/pkg/redactor_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/alecthomas/assert"
-	"github.com/spectralops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/core"
 )
 
 func TestRedactorOverlap(t *testing.T) {

--- a/pkg/teller.go
+++ b/pkg/teller.go
@@ -17,9 +17,9 @@ import (
 
 	"github.com/karrick/godirwalk"
 	"github.com/samber/lo"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
-	"github.com/spectralops/teller/pkg/providers"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/providers"
 	"gopkg.in/yaml.v3"
 )
 

--- a/pkg/teller_test.go
+++ b/pkg/teller_test.go
@@ -13,9 +13,9 @@ import (
 	"testing"
 
 	"github.com/alecthomas/assert"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
-	"github.com/spectralops/teller/pkg/providers"
+	"github.com/tellerops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/logging"
+	"github.com/tellerops/teller/pkg/providers"
 )
 
 // implements both Providers and Provider interface, for testing return only itself.

--- a/pkg/tellerfile.go
+++ b/pkg/tellerfile.go
@@ -3,7 +3,7 @@ package pkg
 import (
 	"os"
 
-	"github.com/spectralops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/core"
 	"gopkg.in/yaml.v2"
 )
 

--- a/pkg/templating.go
+++ b/pkg/templating.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"text/template"
 
-	"github.com/spectralops/teller/pkg/core"
+	"github.com/tellerops/teller/pkg/core"
 )
 
 type Templating struct {

--- a/vendor/github.com/alecthomas/kong/context.go
+++ b/vendor/github.com/alecthomas/kong/context.go
@@ -111,7 +111,7 @@ func (c *Context) Bind(args ...interface{}) {
 //
 // This will typically have to be called like so:
 //
-//    BindTo(impl, (*MyInterface)(nil))
+//	BindTo(impl, (*MyInterface)(nil))
 func (c *Context) BindTo(impl, iface interface{}) {
 	valueOf := reflect.ValueOf(impl)
 	c.bindings[reflect.TypeOf(iface).Elem()] = func() (reflect.Value, error) { return valueOf, nil }
@@ -155,7 +155,7 @@ func (c *Context) Empty() bool {
 }
 
 // Validate the current context.
-func (c *Context) Validate() error { // nolint: gocyclo
+func (c *Context) Validate() error { //nolint: gocyclo
 	err := Visit(c.Model, func(node Visitable, next Next) error {
 		switch node := node.(type) {
 		case *Value:
@@ -324,7 +324,7 @@ func (c *Context) Reset() error {
 	})
 }
 
-func (c *Context) trace(node *Node) (err error) { // nolint: gocyclo
+func (c *Context) trace(node *Node) (err error) { //nolint: gocyclo
 	positional := 0
 
 	flags := []*Flag{}
@@ -342,7 +342,7 @@ func (c *Context) trace(node *Node) (err error) { // nolint: gocyclo
 				switch {
 				case v == "-":
 					fallthrough
-				default: // nolint
+				default: //nolint
 					c.scan.Pop()
 					c.scan.PushTyped(token.Value, PositionalArgumentToken)
 

--- a/vendor/github.com/alecthomas/kong/guesswidth_unix.go
+++ b/vendor/github.com/alecthomas/kong/guesswidth_unix.go
@@ -1,3 +1,4 @@
+//go:build (!appengine && linux) || freebsd || darwin || dragonfly || netbsd || openbsd
 // +build !appengine,linux freebsd darwin dragonfly netbsd openbsd
 
 package kong
@@ -26,9 +27,9 @@ func guessWidth(w io.Writer) int {
 
 		if _, _, err := syscall.Syscall6(
 			syscall.SYS_IOCTL,
-			uintptr(fd), // nolint: unconvert
+			uintptr(fd), //nolint: unconvert
 			uintptr(syscall.TIOCGWINSZ),
-			uintptr(unsafe.Pointer(&dimensions)), // nolint: gas
+			uintptr(unsafe.Pointer(&dimensions)), //nolint: gas
 			0, 0, 0,
 		); err == 0 {
 			if dimensions[1] == 0 {

--- a/vendor/github.com/alecthomas/kong/kong.go
+++ b/vendor/github.com/alecthomas/kong/kong.go
@@ -349,7 +349,7 @@ func (k *Kong) LoadConfig(path string) (Resolver, error) {
 	if err != nil {
 		return nil, err
 	}
-	r, err := os.Open(path) // nolint: gas
+	r, err := os.Open(path) //nolint: gas
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/alecthomas/kong/mapper.go
+++ b/vendor/github.com/alecthomas/kong/mapper.go
@@ -124,7 +124,7 @@ type BoolMapper interface {
 // A MapperFunc is a single function that complies with the Mapper interface.
 type MapperFunc func(ctx *DecodeContext, target reflect.Value) error
 
-func (m MapperFunc) Decode(ctx *DecodeContext, target reflect.Value) error { // nolint: golint
+func (m MapperFunc) Decode(ctx *DecodeContext, target reflect.Value) error { //nolint: golint
 	return m(ctx, target)
 }
 
@@ -218,8 +218,8 @@ func (r *Registry) RegisterKind(kind reflect.Kind, mapper Mapper) *Registry {
 //
 // eg.
 //
-// 		Mapper string `kong:"type='colour'`
-//   	registry.RegisterName("colour", ...)
+//			Mapper string `kong:"type='colour'`
+//	  	registry.RegisterName("colour", ...)
 func (r *Registry) RegisterName(name string, mapper Mapper) *Registry {
 	r.names[name] = mapper
 	return r
@@ -339,7 +339,7 @@ func timeDecoder() MapperFunc {
 	}
 }
 
-func intDecoder(bits int) MapperFunc { // nolint: dupl
+func intDecoder(bits int) MapperFunc { //nolint: dupl
 	return func(ctx *DecodeContext, target reflect.Value) error {
 		t, err := ctx.Scan.PopValue("int")
 		if err != nil {
@@ -365,7 +365,7 @@ func intDecoder(bits int) MapperFunc { // nolint: dupl
 	}
 }
 
-func uintDecoder(bits int) MapperFunc { // nolint: dupl
+func uintDecoder(bits int) MapperFunc { //nolint: dupl
 	return func(ctx *DecodeContext, target reflect.Value) error {
 		t, err := ctx.Scan.PopValue("uint")
 		if err != nil {
@@ -575,7 +575,7 @@ func fileMapper(r *Registry) MapperFunc {
 			file = os.Stdin
 		} else {
 			path = ExpandPath(path)
-			file, err = os.Open(path) // nolint: gosec
+			file, err = os.Open(path) //nolint: gosec
 			if err != nil {
 				return err
 			}
@@ -700,7 +700,7 @@ func urlMapper() MapperFunc {
 //
 // It differs from strings.Split() in that the separator can exist in a field by escaping it with a \. eg.
 //
-//     SplitEscaped(`hello\,there,bob`, ',') == []string{"hello,there", "bob"}
+//	SplitEscaped(`hello\,there,bob`, ',') == []string{"hello,there", "bob"}
 func SplitEscaped(s string, sep rune) (out []string) {
 	if sep == -1 {
 		return []string{s}
@@ -730,7 +730,7 @@ func SplitEscaped(s string, sep rune) (out []string) {
 
 // JoinEscaped joins a slice of strings on sep, but also escapes any instances of sep in the fields with \. eg.
 //
-//     JoinEscaped([]string{"hello,there", "bob"}, ',') == `hello\,there,bob`
+//	JoinEscaped([]string{"hello,there", "bob"}, ',') == `hello\,there,bob`
 func JoinEscaped(s []string, sep rune) string {
 	escaped := []string{}
 	for _, e := range s {
@@ -745,7 +745,7 @@ type NamedFileContentFlag struct {
 	Contents []byte
 }
 
-func (f *NamedFileContentFlag) Decode(ctx *DecodeContext) error { // nolint: golint
+func (f *NamedFileContentFlag) Decode(ctx *DecodeContext) error { //nolint: golint
 	var filename string
 	err := ctx.Scan.PopValueInto("filename", &filename)
 	if err != nil {
@@ -757,7 +757,7 @@ func (f *NamedFileContentFlag) Decode(ctx *DecodeContext) error { // nolint: gol
 		return nil
 	}
 	filename = ExpandPath(filename)
-	data, err := ioutil.ReadFile(filename) // nolint: gosec
+	data, err := ioutil.ReadFile(filename) //nolint: gosec
 	if err != nil {
 		return errors.Errorf("failed to open %q: %s", filename, err)
 	}
@@ -769,7 +769,7 @@ func (f *NamedFileContentFlag) Decode(ctx *DecodeContext) error { // nolint: gol
 // FileContentFlag is a flag value that loads a file's contents into its value.
 type FileContentFlag []byte
 
-func (f *FileContentFlag) Decode(ctx *DecodeContext) error { // nolint: golint
+func (f *FileContentFlag) Decode(ctx *DecodeContext) error { //nolint: golint
 	var filename string
 	err := ctx.Scan.PopValueInto("filename", &filename)
 	if err != nil {
@@ -781,7 +781,7 @@ func (f *FileContentFlag) Decode(ctx *DecodeContext) error { // nolint: golint
 		return nil
 	}
 	filename = ExpandPath(filename)
-	data, err := ioutil.ReadFile(filename) // nolint: gosec
+	data, err := ioutil.ReadFile(filename) //nolint: gosec
 	if err != nil {
 		return errors.Errorf("failed to open %q: %s", filename, err)
 	}

--- a/vendor/github.com/alecthomas/kong/options.go
+++ b/vendor/github.com/alecthomas/kong/options.go
@@ -19,7 +19,7 @@ type Option interface {
 // OptionFunc is function that adheres to the Option interface.
 type OptionFunc func(k *Kong) error
 
-func (o OptionFunc) Apply(k *Kong) error { return o(k) } // nolint: golint
+func (o OptionFunc) Apply(k *Kong) error { return o(k) } //nolint: golint
 
 // Vars sets the variables to use for interpolation into help strings and default values.
 //
@@ -137,8 +137,8 @@ func Writers(stdout, stderr io.Writer) Option {
 //
 // There are two hook points:
 //
-// 		BeforeApply(...) error
-//   	AfterApply(...) error
+//			BeforeApply(...) error
+//	  	AfterApply(...) error
 //
 // Called before validation/assignment, and immediately after validation/assignment, respectively.
 func Bind(args ...interface{}) Option {
@@ -150,7 +150,7 @@ func Bind(args ...interface{}) Option {
 
 // BindTo allows binding of implementations to interfaces.
 //
-// 		BindTo(impl, (*iface)(nil))
+//	BindTo(impl, (*iface)(nil))
 func BindTo(impl, iface interface{}) Option {
 	return OptionFunc(func(k *Kong) error {
 		valueOf := reflect.ValueOf(impl)
@@ -221,7 +221,7 @@ func ConfigureHelp(options HelpOptions) Option {
 // See also ExplicitGroups for a more structured alternative.
 type Groups map[string]string
 
-func (g Groups) Apply(k *Kong) error { // nolint: golint
+func (g Groups) Apply(k *Kong) error { //nolint: golint
 	for key, info := range g {
 		lines := strings.Split(info, "\n")
 		title := strings.TrimSpace(lines[0])

--- a/vendor/github.com/alecthomas/kong/resolver.go
+++ b/vendor/github.com/alecthomas/kong/resolver.go
@@ -22,7 +22,7 @@ type ResolverFunc func(context *Context, parent *Path, flag *Flag) (interface{},
 
 var _ Resolver = ResolverFunc(nil)
 
-func (r ResolverFunc) Resolve(context *Context, parent *Path, flag *Flag) (interface{}, error) { // nolint: golint
+func (r ResolverFunc) Resolve(context *Context, parent *Path, flag *Flag) (interface{}, error) { //nolint: golint
 	return r(context, parent, flag)
 }
 func (r ResolverFunc) Validate(app *Application) error { return nil } //  nolint: golint

--- a/vendor/github.com/alecthomas/kong/scanner.go
+++ b/vendor/github.com/alecthomas/kong/scanner.go
@@ -82,7 +82,7 @@ func (t Token) InferredType() TokenType {
 		return t.Type
 	}
 	if v, ok := t.Value.(string); ok {
-		if strings.HasPrefix(v, "--") { // nolint: gocritic
+		if strings.HasPrefix(v, "--") { //nolint: gocritic
 			return FlagToken
 		} else if v == "-" {
 			return PositionalArgumentToken
@@ -109,7 +109,7 @@ func (t Token) IsValue() bool {
 //
 // For example, the token "--foo=bar" will be split into the following by the parser:
 //
-// 		[{FlagToken, "foo"}, {FlagValueToken, "bar"}]
+//	[{FlagToken, "foo"}, {FlagValueToken, "bar"}]
 type Scanner struct {
 	args []Token
 }

--- a/vendor/github.com/alecthomas/repr/repr.go
+++ b/vendor/github.com/alecthomas/repr/repr.go
@@ -142,7 +142,7 @@ func (p *Printer) Println(vs ...interface{}) {
 	fmt.Fprintln(p.w)
 }
 
-func (p *Printer) reprValue(seen map[reflect.Value]bool, v reflect.Value, indent string, showType bool) { // nolint: gocyclo
+func (p *Printer) reprValue(seen map[reflect.Value]bool, v reflect.Value, indent string, showType bool) { //nolint: gocyclo
 	if seen[v] {
 		fmt.Fprint(p.w, "...")
 		return

--- a/vendor/github.com/containerd/containerd/sys/stat_bsd.go
+++ b/vendor/github.com/containerd/containerd/sys/stat_bsd.go
@@ -1,3 +1,4 @@
+//go:build darwin || freebsd || netbsd
 // +build darwin freebsd netbsd
 
 /*
@@ -40,5 +41,5 @@ func StatMtime(st *syscall.Stat_t) syscall.Timespec {
 
 // StatATimeAsTime returns the access time as a time.Time
 func StatATimeAsTime(st *syscall.Stat_t) time.Time {
-	return time.Unix(int64(st.Atimespec.Sec), int64(st.Atimespec.Nsec)) // nolint: unconvert
+	return time.Unix(int64(st.Atimespec.Sec), int64(st.Atimespec.Nsec)) //nolint: unconvert
 }

--- a/vendor/github.com/containerd/containerd/sys/stat_openbsd.go
+++ b/vendor/github.com/containerd/containerd/sys/stat_openbsd.go
@@ -1,3 +1,4 @@
+//go:build openbsd
 // +build openbsd
 
 /*
@@ -41,5 +42,5 @@ func StatMtime(st *syscall.Stat_t) syscall.Timespec {
 // StatATimeAsTime returns st.Atim as a time.Time
 func StatATimeAsTime(st *syscall.Stat_t) time.Time {
 	// The int64 conversions ensure the line compiles for 32-bit systems as well.
-	return time.Unix(int64(st.Atim.Sec), int64(st.Atim.Nsec)) // nolint: unconvert
+	return time.Unix(int64(st.Atim.Sec), int64(st.Atim.Nsec)) //nolint: unconvert
 }

--- a/vendor/github.com/containerd/containerd/sys/stat_unix.go
+++ b/vendor/github.com/containerd/containerd/sys/stat_unix.go
@@ -1,3 +1,4 @@
+//go:build linux || solaris
 // +build linux solaris
 
 /*
@@ -40,5 +41,5 @@ func StatMtime(st *syscall.Stat_t) syscall.Timespec {
 
 // StatATimeAsTime returns st.Atim as a time.Time
 func StatATimeAsTime(st *syscall.Stat_t) time.Time {
-	return time.Unix(int64(st.Atim.Sec), int64(st.Atim.Nsec)) // nolint: unconvert
+	return time.Unix(int64(st.Atim.Sec), int64(st.Atim.Nsec)) //nolint: unconvert
 }

--- a/vendor/github.com/containerd/continuity/fs/du_unix.go
+++ b/vendor/github.com/containerd/continuity/fs/du_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*
@@ -27,10 +28,11 @@ import (
 
 // blocksUnitSize is the unit used by `st_blocks` in `stat` in bytes.
 // See https://man7.org/linux/man-pages/man2/stat.2.html
-//   st_blocks
-//     This field indicates the number of blocks allocated to the
-//     file, in 512-byte units.  (This may be smaller than
-//     st_size/512 when the file has holes.)
+//
+//	st_blocks
+//	  This field indicates the number of blocks allocated to the
+//	  file, in 512-byte units.  (This may be smaller than
+//	  st_size/512 when the file has holes.)
 const blocksUnitSize = 512
 
 type inode struct {
@@ -42,9 +44,9 @@ type inode struct {
 func newInode(stat *syscall.Stat_t) inode {
 	return inode{
 		// Dev is uint32 on darwin/bsd, uint64 on linux/solaris/freebsd
-		dev: uint64(stat.Dev), // nolint: unconvert
+		dev: uint64(stat.Dev), //nolint: unconvert
 		// Ino is uint32 on bsd, uint64 on darwin/linux/solaris/freebsd
-		ino: uint64(stat.Ino), // nolint: unconvert
+		ino: uint64(stat.Ino), //nolint: unconvert
 	}
 }
 

--- a/vendor/github.com/containerd/continuity/fs/hardlink_unix.go
+++ b/vendor/github.com/containerd/continuity/fs/hardlink_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*
@@ -30,5 +31,5 @@ func getLinkInfo(fi os.FileInfo) (uint64, bool) {
 	}
 
 	// Ino is uint32 on bsd, uint64 on darwin/linux/solaris
-	return uint64(s.Ino), !fi.IsDir() && s.Nlink > 1 // nolint: unconvert
+	return uint64(s.Ino), !fi.IsDir() && s.Nlink > 1 //nolint: unconvert
 }

--- a/vendor/github.com/containerd/continuity/fs/stat_darwinfreebsd.go
+++ b/vendor/github.com/containerd/continuity/fs/stat_darwinfreebsd.go
@@ -1,3 +1,4 @@
+//go:build darwin || freebsd
 // +build darwin freebsd
 
 /*
@@ -40,5 +41,5 @@ func StatMtime(st *syscall.Stat_t) syscall.Timespec {
 
 // StatATimeAsTime returns the access time as a time.Time
 func StatATimeAsTime(st *syscall.Stat_t) time.Time {
-	return time.Unix(int64(st.Atimespec.Sec), int64(st.Atimespec.Nsec)) // nolint: unconvert
+	return time.Unix(int64(st.Atimespec.Sec), int64(st.Atimespec.Nsec)) //nolint: unconvert
 }

--- a/vendor/github.com/containerd/continuity/fs/stat_linuxopenbsd.go
+++ b/vendor/github.com/containerd/continuity/fs/stat_linuxopenbsd.go
@@ -1,3 +1,4 @@
+//go:build linux || openbsd
 // +build linux openbsd
 
 /*
@@ -41,5 +42,5 @@ func StatMtime(st *syscall.Stat_t) syscall.Timespec {
 // StatATimeAsTime returns st.Atim as a time.Time
 func StatATimeAsTime(st *syscall.Stat_t) time.Time {
 	// The int64 conversions ensure the line compiles for 32-bit systems as well.
-	return time.Unix(int64(st.Atim.Sec), int64(st.Atim.Nsec)) // nolint: unconvert
+	return time.Unix(int64(st.Atim.Sec), int64(st.Atim.Nsec)) //nolint: unconvert
 }

--- a/vendor/github.com/cpuguy83/go-md2man/v2/md2man/roff.go
+++ b/vendor/github.com/cpuguy83/go-md2man/v2/md2man/roff.go
@@ -52,7 +52,7 @@ const (
 
 // NewRoffRenderer creates a new blackfriday Renderer for generating roff documents
 // from markdown
-func NewRoffRenderer() *roffRenderer { // nolint: golint
+func NewRoffRenderer() *roffRenderer { //nolint: golint
 	var extensions blackfriday.Extensions
 
 	extensions |= blackfriday.NoIntraEmphasis
@@ -306,7 +306,7 @@ func countColumns(node *blackfriday.Node) int {
 }
 
 func out(w io.Writer, output string) {
-	io.WriteString(w, output) // nolint: errcheck
+	io.WriteString(w, output) //nolint: errcheck
 }
 
 func escapeSpecialChars(w io.Writer, text []byte) {
@@ -323,7 +323,7 @@ func escapeSpecialChars(w io.Writer, text []byte) {
 			i++
 		}
 		if i > org {
-			w.Write(text[org:i]) // nolint: errcheck
+			w.Write(text[org:i]) //nolint: errcheck
 		}
 
 		// escape a character
@@ -331,6 +331,6 @@ func escapeSpecialChars(w io.Writer, text []byte) {
 			break
 		}
 
-		w.Write([]byte{'\\', text[i]}) // nolint: errcheck
+		w.Write([]byte{'\\', text[i]}) //nolint: errcheck
 	}
 }

--- a/vendor/github.com/docker/docker/pkg/archive/archive_unix.go
+++ b/vendor/github.com/docker/docker/pkg/archive/archive_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package archive // import "github.com/docker/docker/pkg/archive"
@@ -51,8 +52,8 @@ func setHeaderForSpecialDevice(hdr *tar.Header, name string, stat interface{}) (
 		// Currently go does not fill in the major/minors
 		if s.Mode&unix.S_IFBLK != 0 ||
 			s.Mode&unix.S_IFCHR != 0 {
-			hdr.Devmajor = int64(unix.Major(uint64(s.Rdev))) // nolint: unconvert
-			hdr.Devminor = int64(unix.Minor(uint64(s.Rdev))) // nolint: unconvert
+			hdr.Devmajor = int64(unix.Major(uint64(s.Rdev))) //nolint: unconvert
+			hdr.Devminor = int64(unix.Minor(uint64(s.Rdev))) //nolint: unconvert
 		}
 	}
 

--- a/vendor/github.com/docker/docker/pkg/system/stat_linux.go
+++ b/vendor/github.com/docker/docker/pkg/system/stat_linux.go
@@ -9,7 +9,7 @@ func fromStatT(s *syscall.Stat_t) (*StatT, error) {
 		uid:  s.Uid,
 		gid:  s.Gid,
 		// the type is 32bit on mips
-		rdev: uint64(s.Rdev), // nolint: unconvert
+		rdev: uint64(s.Rdev), //nolint: unconvert
 		mtim: s.Mtim}, nil
 }
 

--- a/vendor/github.com/gopasspw/gopass/internal/backend/crypto/gpg/colons/parse_colons.go
+++ b/vendor/github.com/gopasspw/gopass/internal/backend/crypto/gpg/colons/parse_colons.go
@@ -10,13 +10,13 @@ import (
 )
 
 var (
-	// nolint:godot
+	//nolint:godot
 	// John Doe (user) <john.doe@example.com>
 	reUIDComment = regexp.MustCompile(`([^(<]+)\s+(\([^)]+\))\s+<([^>]+)>`)
-	// nolint:godot
+	//nolint:godot
 	// John Doe <john.doe@example.com>
 	reUID = regexp.MustCompile(`([^(<]+)\s+<([^>]+)>`)
-	// nolint:godot
+	//nolint:godot
 	// John Doe (user)
 	reUIDNoEmailComment = regexp.MustCompile(`([^(<]+)\s+(\([^)]+\))`)
 )

--- a/vendor/github.com/gopasspw/gopass/internal/store/leaf/reencrypt.go
+++ b/vendor/github.com/gopasspw/gopass/internal/store/leaf/reencrypt.go
@@ -17,8 +17,9 @@ import (
 	"github.com/gopasspw/gopass/pkg/termio"
 )
 
-// nolint:ifshort
 // reencrypt will re-encrypt all entries for the current recipients.
+//
+//nolint:ifshort
 func (s *Store) reencrypt(ctx context.Context) error {
 	entries, err := s.List(ctx, "")
 	if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -548,8 +548,6 @@ github.com/mattn/lastpass-go/ecb
 # github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
 ## explicit
 github.com/mgutz/ansi
-# github.com/miekg/dns v1.1.35
-## explicit; go 1.12
 # github.com/mitchellh/go-homedir v1.1.0
 ## explicit
 github.com/mitchellh/go-homedir


### PR DESCRIPTION

## Description
On arch linux  `go get -u github.com/tellerops/teller` is throwing below error
```
go: downloading github.com/tellerops/teller v1.5.6
go: github.com/tellerops/teller@v1.5.6: parsing go.mod:
	module declares its path as: github.com/spectralops/teller
	       but was required as: github.com/tellerops/teller
```


## Motivation and Context
It is required to install teller using go itself
