### PR TITLE
keepass: unexpected leading slash for root items

### DIFF
--- a/pkg/providers/keypass.go
+++ b/pkg/providers/keypass.go
@@ -24,7 +24,7 @@ type KeyPass struct {
 
 const KeyPassName = "KeyPass"
 
-//nolint
+// nolint
 func init() {
 	metaInfo := core.MetaInfo{
 		Description:    "Keypass",
@@ -177,7 +177,12 @@ func (k *KeyPass) prepareGroups(path string, groups []gokeepasslib.Group, mapDat
 		// if entries found, adding the entry data fo the list
 		if len(group.Entries) > 0 {
 			for _, entry := range group.Entries { //nolint
-				mapData[fmt.Sprintf("%s/%s/%s", path, group.Name, entry.GetTitle())] = entry
+				if path == "" { // prevent unexpected leading slash for entries in root
+					mapData[fmt.Sprintf("%s/%s", group.Name, entry.GetTitle())] = entry
+				} else {
+					mapData[fmt.Sprintf("%s/%s/%s", path, group.Name, entry.GetTitle())] = entry
+				}
+
 			}
 		}
 		if len(group.Groups) > 0 {


### PR DESCRIPTION


## Description
Keepass provider entries in root of database should be created without leading slash
for consistency between root and non-root Keepass items

## Motivation and Context
Inconsistent path creates confusion and it made me think that Keepass
support is broken, because path to entry was not predictable.

## How Has This Been Tested?
Created Keepass database with entries in root and inside groups.
Both should have path without need for leading slash. E.g. 

```
  KeyPass:
    env:
      world:
        path: Root/hello
      redis:
        path: Root/redis/config/foobar
```

Please consider this change.