### PR TITLE
Add quotes around values that include whitespace characters

### DIFF
--- a/pkg/teller.go
+++ b/pkg/teller.go
@@ -6,12 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/karrick/godirwalk"
-	"github.com/samber/lo"
-	"github.com/spectralops/teller/pkg/core"
-	"github.com/spectralops/teller/pkg/logging"
-	"github.com/spectralops/teller/pkg/providers"
-	"gopkg.in/yaml.v3"
 	"io"
 	"os"
 	"os/exec"
@@ -22,6 +16,13 @@ import (
 	"text/template"
 	"time"
 	"unicode"
+
+	"github.com/karrick/godirwalk"
+	"github.com/samber/lo"
+	"github.com/spectralops/teller/pkg/core"
+	"github.com/spectralops/teller/pkg/logging"
+	"github.com/spectralops/teller/pkg/providers"
+	"gopkg.in/yaml.v3"
 )
 
 // Teller

--- a/pkg/teller.go
+++ b/pkg/teller.go
@@ -6,21 +6,22 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"sort"
-	"strings"
-	"text/template"
-	"time"
-
 	"github.com/karrick/godirwalk"
 	"github.com/samber/lo"
 	"github.com/spectralops/teller/pkg/core"
 	"github.com/spectralops/teller/pkg/logging"
 	"github.com/spectralops/teller/pkg/providers"
 	"gopkg.in/yaml.v3"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"text/template"
+	"time"
+	"unicode"
 )
 
 // Teller
@@ -118,9 +119,17 @@ func (tl *Teller) ExportDotenv() string {
 
 	for i := range tl.Entries {
 		v := tl.Entries[i]
-		fmt.Fprintf(&b, "%s=%s\n", v.Key, v.Value)
+		fmt.Fprintf(&b, "%s=%s\n", v.Key, maybeQuote(v.Value))
 	}
 	return b.String()
+}
+
+// maybeQuote quotes the incoming value if there is a whitespace character in it
+func maybeQuote(in string) string {
+	if whitespaceRuneIdx := strings.IndexFunc(in, unicode.IsSpace); whitespaceRuneIdx == -1 {
+		return in
+	}
+	return strconv.Quote(in)
 }
 
 func (tl *Teller) ExportYAML() (out string, err error) {

--- a/pkg/teller_test.go
+++ b/pkg/teller_test.go
@@ -188,18 +188,37 @@ func TestTellerExports(t *testing.T) {
 		Logger: getLogger(),
 		Entries: []core.EnvEntry{
 			{Key: "k", Value: "v", ProviderName: "test-provider", ResolvedPath: "path/kv"},
+			{Key: "multiword", Value: "two words", ProviderName: "test-provider", ResolvedPath: "path/multiword"},
 		},
 	}
 
 	b = tl.ExportEnv()
-	assert.Equal(t, b, "#!/bin/sh\nexport k='v'\n")
+	assert.Equal(t, b,
+		`#!/bin/sh
+export k='v'
+export multiword='two words'
+`)
 
 	b, err := tl.ExportYAML()
 	assert.NoError(t, err)
-	assert.Equal(t, b, "k: v\n")
+	assert.Equal(t, b,
+		`k: v
+multiword: two words
+`)
 	b, err = tl.ExportJSON()
 	assert.NoError(t, err)
-	assert.Equal(t, b, "{\n  \"k\": \"v\"\n}")
+	assert.Equal(t, b,
+		`{
+  "k": "v",
+  "multiword": "two words"
+}`)
+
+	b = tl.ExportDotenv()
+	assert.NoError(t, err)
+	assert.Equal(t, b,
+		`k=v
+multiword="two words"
+`)
 }
 
 func TestTellerShExportEscaped(t *testing.T) {


### PR DESCRIPTION
## Related Issues
#240 

## Description
This change puts quotes around values of variables (that include whitespace characters) in the `teller env` output

## Motivation and Context
This change makes it possible to have string values that contain whitespace characters coming from the providers and be valid env variables in the output of the `teller env` command
The existing issue is #240 

## How Has This Been Tested?
Added a test case in the TestTellerExports test func for the `ExportDotenv` code path
I ran `make test` and it completed successfully
This only affects the `ExportDotenv` code path, but we might want to have a similar approach for yaml

# Checklist
- [x] Tests
- [ ] Documentation
- [x] Linting