### PR TITLE
feat: add support for AWS SM plaintext secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,6 +636,7 @@ Your standard `AWS_DEFAULT_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
 - Key format
   - `env_sync` - path based
   - `env` - path based
+- Handles plain text secrets (rather than key/value pairs) via the `plaintext: true` property
 
 ### Example Config
 
@@ -647,6 +648,19 @@ aws_secretsmanager:
     MG_KEY:
       path: /prod/billing-svc/vars/mg
 ```
+
+Plain text secrets are useful for files; instead of using the usual JSON encoded key/value pairs. This example shows how to get a plaintext secret:
+
+```yaml
+aws_secretsmanager:
+  env_sync:
+    path: /prod/billing-svc
+  env:
+    MY_FILE:
+      path: /prod/billing-svc/some-file
+      plaintext: true
+```
+
 
 ## AWS Parameter store
 

--- a/pkg/core/types.go
+++ b/pkg/core/types.go
@@ -13,6 +13,9 @@ const (
 	Medium Severity = "medium"
 	Low    Severity = "low"
 	None   Severity = "none"
+
+	// PlainTextKey the key used for plaintext secrets
+	PlainTextKey = "plaintext"
 )
 
 type RemapKeyPath struct {
@@ -29,6 +32,7 @@ type KeyPath struct {
 	RemapWith  *map[string]RemapKeyPath `yaml:"remap_with,omitempty"`
 	Decrypt    bool                     `yaml:"decrypt,omitempty"`
 	Optional   bool                     `yaml:"optional,omitempty"`
+	Plaintext  bool                     `yaml:"plaintext,omitempty"`
 	Severity   Severity                 `yaml:"severity,omitempty" default:"high"`
 	RedactWith string                   `yaml:"redact_with,omitempty" default:"**REDACTED**"`
 	Source     string                   `yaml:"source,omitempty"`
@@ -43,6 +47,9 @@ type WizardAnswers struct {
 }
 
 func (k *KeyPath) EffectiveKey() string {
+	if k.Plaintext {
+		return PlainTextKey
+	}
 	key := k.Env
 	if k.Field != "" {
 		key = k.Field
@@ -94,24 +101,26 @@ func (k *KeyPath) FoundWithKey(key, v string) EnvEntry {
 
 func (k *KeyPath) WithEnv(env string) KeyPath {
 	return KeyPath{
-		Env:      env,
-		Path:     k.Path,
-		Field:    k.Field,
-		Decrypt:  k.Decrypt,
-		Optional: k.Optional,
-		Source:   k.Source,
-		Sink:     k.Sink,
+		Env:       env,
+		Path:      k.Path,
+		Field:     k.Field,
+		Decrypt:   k.Decrypt,
+		Optional:  k.Optional,
+		Source:    k.Source,
+		Sink:      k.Sink,
+		Plaintext: k.Plaintext,
 	}
 }
 func (k *KeyPath) SwitchPath(path string) KeyPath {
 	return KeyPath{
-		Path:     path,
-		Field:    k.Field,
-		Env:      k.Env,
-		Decrypt:  k.Decrypt,
-		Optional: k.Optional,
-		Source:   k.Source,
-		Sink:     k.Sink,
+		Path:      path,
+		Field:     k.Field,
+		Env:       k.Env,
+		Decrypt:   k.Decrypt,
+		Optional:  k.Optional,
+		Source:    k.Source,
+		Sink:      k.Sink,
+		Plaintext: k.Plaintext,
 	}
 }
 

--- a/pkg/providers/aws_secretsmanager.go
+++ b/pkg/providers/aws_secretsmanager.go
@@ -38,7 +38,7 @@ var defaultDeletionRecoveryWindowInDays int64 = 7
 
 const versionSplit = ","
 
-//nolint
+// nolint
 func init() {
 	metaInfo := core.MetaInfo{
 		Name:           "aws_secretsmanager",
@@ -234,6 +234,11 @@ func (a *AWSSecretsManager) getSecret(kp core.KeyPath) (map[string]string, error
 	case err == nil:
 		if res == nil || res.SecretString == nil {
 			return nil, fmt.Errorf("data not found at %q", kp.Path)
+		}
+		if kp.Plaintext {
+			return map[string]string{
+				core.PlainTextKey: *res.SecretString,
+			}, nil
 		}
 
 		var secret map[string]interface{}

--- a/pkg/providers/aws_secretsmanager_test.go
+++ b/pkg/providers/aws_secretsmanager_test.go
@@ -34,6 +34,25 @@ func TestAWSSecretsManager(t *testing.T) {
 	AssertProvider(t, &s, true)
 }
 
+func TestAWSSecretsManagerPlainText(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	// Assert that Bar() is invoked.
+	defer ctrl.Finish()
+	client := mock_providers.NewMockAWSSecretsManagerClient(ctrl)
+	path := "settings/prod/billing-svc"
+	in := secretsmanager.GetSecretValueInput{SecretId: &path}
+	data := `hello-world`
+	out := secretsmanager.GetSecretValueOutput{
+		SecretString: &data,
+	}
+	client.EXPECT().GetSecretValue(gomock.Any(), gomock.Eq(&in)).Return(&out, nil).AnyTimes()
+	s := AWSSecretsManager{
+		client: client,
+		logger: GetTestLogger(),
+	}
+	AssertProviderPlainText(t, &s, data)
+}
+
 func TestAWSSecretsManagerFailures(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	// Assert that Bar() is invoked.

--- a/pkg/providers/helpers_test.go
+++ b/pkg/providers/helpers_test.go
@@ -33,6 +33,21 @@ func AssertProvider(t *testing.T, s core.Provider, sync bool) {
 	}
 }
 
+func AssertProviderPlainText(t *testing.T, s core.Provider, expected string) {
+	p := core.NewPopulate(map[string]string{"stage": "prod"})
+
+	kp := p.KeyPath(core.KeyPath{Field: "MG_KEY", Path: "settings/{{stage}}/billing-svc", Decrypt: true, Plaintext: true})
+	kpenv := p.KeyPath(core.KeyPath{Env: "MG_KEY", Path: "settings/{{stage}}/billing-svc", Decrypt: true, Plaintext: true})
+
+	ent, err := s.Get(kp)
+	assert.Nil(t, err)
+	assert.Equal(t, ent.Value, expected)
+
+	ent, err = s.Get(kpenv)
+	assert.Nil(t, err)
+	assert.Equal(t, ent.Value, expected)
+}
+
 func ConfigurableAssertProvider(t *testing.T, s core.Provider, sync bool, setField bool) {
 	p := core.NewPopulate(map[string]string{"stage": "prod"})
 


### PR DESCRIPTION
in addition to the key/value pair secrets

## Description
currently AWS Secret Manager only supports key/value pair secrets

this PR adds the ability to define a secret as being plaintext which is common when using secrets for things like files


## Motivation and Context

supports fetching plaintext secrets from AWS Secret Manager which are currently not supported

## How Has This Been Tested?

I tested it against AWS Secrets Manager 

# Checklist
- [X] Tests
- [X] Documentation
- [X] Linting