### PR TITLE
Remove Product Hunt from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@
 <b>:pager: Create easy and clean workflows for working with cloud environments</b>
 <br/>
 <b>:mag_right: Scan for secrets and fight secret sprawl</b>
-<br/><br/><br/>
-   <a href="https://www.producthunt.com/posts/teller-3?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-teller-3" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=332313&theme=light" alt="Teller - The open-source universal secret manager for developers | Product Hunt" style="width: 250px; height: 54px;" width="150"  /></a><br/>
-<br/><br/><br/>
 <hr/>
 </p>
 


### PR DESCRIPTION
Product hunt has this product flagged for removal. Should it be removed from the readme description?

## Related Issues
N/A

## Description
Remove product hunt from the Readme

## Motivation and Context
As a first time discoverer of Teller it lowers my confidence to use the tool when I see both a missing image on the Readme as well as Product Hunt telling me this product has been flagged for removal

![Screenshot 2024-04-19 at 10 59 34 AM](https://github.com/tellerops/teller/assets/37553025/9285e7d1-d279-40c7-9b36-407ad55745d1)
![Screenshot 2024-04-19 at 10 56 45 AM](https://github.com/tellerops/teller/assets/37553025/8dcf6136-8158-40f2-82f1-b2bc4645bb15)


## How Has This Been Tested?
N/A

# Checklist
- [-] Tests
- [x] Documentation
- [-] Linting